### PR TITLE
Add Vertex flag plumbing for trainer configuration

### DIFF
--- a/vertex/package/liquid_llm_vertex_full/src/liquid_llm/training/loop.py
+++ b/vertex/package/liquid_llm_vertex_full/src/liquid_llm/training/loop.py
@@ -1,0 +1,330 @@
+import time
+from pathlib import Path
+import torch
+from transformers import AutoModelForCausalLM
+from .metrics import cross_entropy, Meter
+from .evaluation import evaluate
+
+
+def _get_logits(output):
+    """Handle both HF-style outputs with `.logits` and plain tensors."""
+    if hasattr(output, "logits"):
+        return output.logits
+    return output
+
+
+def _count_tokens(labels, fallback_tokens):
+    """
+    Prefer counting tokens actually contributing to loss (labels != -100).
+    Fallback to total tokens if labels don't use ignore_index.
+    """
+    if labels is None:
+        return fallback_tokens
+    if labels.dtype == torch.long and (labels == -100).any():
+        return (labels != -100).sum().item()
+    return fallback_tokens
+
+
+def _save_ckpt(ckptio, state, step, filename, log):
+    """Helper to save a checkpoint and log locations."""
+    state_dict = {
+        "model": state["model"].state_dict(),
+        "optimizer": state["optimizer"].state_dict(),
+        "scheduler": state["scheduler"].state_dict(),
+        "step": step,
+    }
+    local, uri = ckptio(state_dict, state["local_outdir"], state["gcs_outdir"], filename=filename)
+    log.info(f"[ckpt] saved {local}" + (f" and uploaded to {uri}" if uri else ""))
+    return local
+
+
+# -----------------------------
+# Unified pruning helpers
+# -----------------------------
+def _list_sorted_by_mtime(pattern: str, local_outdir: str):
+    """Return Path list sorted by mtime (oldest first)."""
+    return sorted(Path(local_outdir).glob(pattern), key=lambda p: p.stat().st_mtime)
+
+
+def _prune_files(files, keep_k: int | None, retention_secs: int | None, now: float, log, label: str):
+    """
+    Apply (1) optional age-based prune, then (2) optional count-based prune.
+    Files should be oldest-first.
+    """
+    removed = 0
+    survivors = list(files)
+
+    # 1) Age-based prune
+    if retention_secs is not None and retention_secs > 0:
+        tmp = []
+        for p in survivors:
+            try:
+                age = now - p.stat().st_mtime
+                if age > retention_secs:
+                    p.unlink(missing_ok=True)
+                    removed += 1
+                else:
+                    tmp.append(p)
+            except Exception as e:
+                log.warning(f"[ckpt] {label} prune skip {p}: {e}")
+                tmp.append(p)
+        survivors = tmp
+
+    # 2) Count-based prune (keep most recent K by mtime)
+    if keep_k is not None and keep_k >= 0:
+        if keep_k == 0:
+            for p in survivors:
+                try:
+                    p.unlink(missing_ok=True)
+                    removed += 1
+                except Exception as e:
+                    log.warning(f"[ckpt] {label} prune skip {p}: {e}")
+            survivors = []
+        elif len(survivors) > keep_k:
+            to_delete = survivors[: len(survivors) - keep_k]  # oldest first
+            for p in to_delete:
+                try:
+                    p.unlink(missing_ok=True)
+                    removed += 1
+                except Exception as e:
+                    log.warning(f"[ckpt] {label} prune skip {p}: {e}")
+            survivors = survivors[len(survivors) - keep_k :]
+
+    if removed:
+        log.info(f"[ckpt] pruned {removed} old {label} checkpoints.")
+    return survivors
+
+
+def _prune_time_ckpts(local_outdir: str, log, retention_secs: int | None, keep_k: int | None, now: float | None = None):
+    """
+    Prune *time-based* checkpoints matching `ckpt_time_*.pt`.
+    """
+    now = now or time.time()
+    files = _list_sorted_by_mtime("ckpt_time_*.pt", local_outdir)
+    _prune_files(files, keep_k=keep_k, retention_secs=retention_secs, now=now, log=log, label="time-based")
+
+
+def _prune_best_ckpts(local_outdir: str, log, retention_secs: int | None, keep_k: int | None, now: float | None = None):
+    """
+    Prune versioned best checkpoints saved as `ckpt_best_*.pt`.
+    NOTE: Does NOT remove the rolling `best.pt`.
+    """
+    now = now or time.time()
+    files = _list_sorted_by_mtime("ckpt_best_*.pt", local_outdir)
+    if not files:
+        return
+    _prune_files(files, keep_k=keep_k, retention_secs=retention_secs, now=now, log=log, label="best")
+
+
+def _prune_step_ckpts(local_outdir: str, log, retention_secs: int | None, keep_k: int | None, now: float | None = None):
+    """
+    Prune step-based checkpoints saved as `ckpt_step_*.pt`.
+    """
+    now = now or time.time()
+    files = _list_sorted_by_mtime("ckpt_step_*.pt", local_outdir)
+    if not files:
+        return
+    _prune_files(files, keep_k=keep_k, retention_secs=retention_secs, now=now, log=log, label="step-based")
+
+
+def train_loop(state):
+    model         = state["model"]
+    device        = state["device"]
+    teacher_name  = state["teacher_name"]
+    kd_alpha      = state.get("kd_alpha", 0.5)
+    kd_temperature = state.get("kd_temperature", 1.0)
+    train_loader  = state["train_loader"]
+    val_loader    = state["val_loader"]
+    optimizer     = state["optimizer"]
+    scheduler     = state["scheduler"]
+    save_every    = state["save_every"]
+    eval_every    = state["eval_every"]
+    log           = state["log"]
+    total_steps   = state["train_steps"]
+    ckptio        = state["ckptio"]
+    precision     = state.get("precision", "fp16")
+    grad_clip     = state.get("grad_clip", 1.0)
+
+    # --- Time-based checkpoint cadence & retention ---
+    time_ckpt_secs            = int(state.get("time_ckpt_secs", 1800))            # every 30 min by default
+    time_ckpt_retention_secs  = state.get("time_ckpt_retention_secs", 14400)      # 4 hours by default
+    time_ckpt_keep_k          = state.get("time_ckpt_keep_k", None)               # default: count-unbounded
+    if time_ckpt_retention_secs is not None:
+        time_ckpt_retention_secs = int(time_ckpt_retention_secs)
+    last_time_ckpt_ts         = float(state.get("last_time_ckpt_ts", 0.0))
+
+    # --- Best checkpoint retention controls (versioned snapshots) ---
+    best_ckpt_keep_k          = int(state.get("best_ckpt_keep_k", 3))             # keep K versioned best files
+    best_ckpt_retention_secs  = state.get("best_ckpt_retention_secs", None)       # optional age prune
+    if best_ckpt_retention_secs is not None:
+        best_ckpt_retention_secs = int(best_ckpt_retention_secs)
+
+    # --- Step checkpoint retention controls ---
+    step_ckpt_keep_k          = int(state.get("step_ckpt_keep_k", 5))             # default keep last 5 step ckpts
+    step_ckpt_retention_secs  = state.get("step_ckpt_retention_secs", None)       # optional age prune
+    if step_ckpt_retention_secs is not None:
+        step_ckpt_retention_secs = int(step_ckpt_retention_secs)
+
+    # Track best validation loss for "best.pt"
+    best_val_loss = float(state.get("best_val_loss", float("inf")))
+    best_path_local = None
+
+    # Optional teacher (for KD)
+    teacher = None
+    if kd_alpha and kd_alpha > 0:
+        teacher = AutoModelForCausalLM.from_pretrained(teacher_name).to(device).eval()
+        for p in teacher.parameters():
+            p.requires_grad_(False)
+
+    step = state.get("step", 0)
+    scaler = torch.amp.GradScaler("cuda", enabled=(precision == "fp16"))
+
+    # Meters for logging
+    tok_meter   = Meter()  # token-weighted mean (comparable to eval CE)
+    batch_meter = Meter()  # batch-weighted mean (debug)
+
+    since_log_tokens   = 0
+    since_log_examples = 0
+    t0 = time.time()
+    start_time = t0  # for first time-based ckpt window
+
+    model.train()
+    while step < total_steps:
+        for batch in train_loader:
+            step += 1
+            input_ids = batch["input_ids"].to(device, non_blocking=True)
+            labels    = batch["labels"].to(device, non_blocking=True)
+
+            optimizer.zero_grad(set_to_none=True)
+            with torch.amp.autocast("cuda", enabled=(precision == "fp16")):
+                logits_s = _get_logits(model(input_ids))
+                loss_ce  = cross_entropy(logits_s, labels)
+
+                if teacher is not None and kd_alpha > 0:
+                    with torch.no_grad():
+                        logits_t = _get_logits(teacher(input_ids))
+                    T = kd_temperature
+                    logprob_s = torch.nn.functional.log_softmax(logits_s / T, dim=-1)
+                    prob_t    = torch.nn.functional.softmax(logits_t / T, dim=-1)
+                    loss_kd   = torch.nn.functional.kl_div(
+                        logprob_s, prob_t, reduction="batchmean"
+                    ) * (T * T)
+                    loss = (1 - kd_alpha) * loss_ce + kd_alpha * loss_kd
+                else:
+                    loss = loss_ce
+
+            scaler.scale(loss).backward()
+            if grad_clip is not None and grad_clip > 0:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+            scaler.step(optimizer)
+            scaler.update()
+            scheduler.step()
+
+            # ===== Logging & meters =====
+            tokens_in_batch = input_ids.numel()
+            contrib_tokens  = _count_tokens(labels, tokens_in_batch)
+
+            tok_meter.update(loss.item(), k=contrib_tokens)
+            batch_meter.update(loss.item(), k=input_ids.size(0))
+
+            since_log_tokens   += contrib_tokens
+            since_log_examples += input_ids.size(0)
+
+            # Periodic training log
+            if step % state["log_interval"] == 0:
+                elapsed = max(time.time() - t0, 1e-9)
+                tok_per_sec  = since_log_tokens / elapsed
+                ex_per_sec   = since_log_examples / elapsed
+                log.info(
+                    f"step={step}/{total_steps} "
+                    f"loss_tok_mean={tok_meter.avg:.4f} "
+                    f"loss_batch_mean={batch_meter.avg:.4f} "
+                    f"tok/s={tok_per_sec:.0f} "
+                    f"ex/s={ex_per_sec:.1f}"
+                )
+                tok_meter   = Meter()
+                batch_meter = Meter()
+                since_log_tokens   = 0
+                since_log_examples = 0
+                t0 = time.time()
+
+            # Scheduled eval + best checkpointing
+            if step % eval_every == 0:
+                model.eval()
+                metrics = evaluate(model, val_loader, device=device)
+                val_loss = float(metrics["val_loss"])
+                log.info(f"[eval] step={step} val_loss={val_loss:.4f} ppl={metrics['val_ppl']:.2f}")
+
+                # New best? Save/overwrite best.pt and versioned best snapshot
+                if val_loss < best_val_loss:
+                    best_val_loss = val_loss
+
+                    # Rolling "best.pt" (always the current best)
+                    best_path_local = _save_ckpt(
+                        ckptio, state, step, filename="best.pt", log=log
+                    )
+
+                    # Versioned best snapshot for historical/top-K retention
+                    vers_name = f"ckpt_best_step{step}_vl{val_loss:.4f}.pt"
+                    _save_ckpt(ckptio, state, step, filename=vers_name, log=log)
+
+                    # Prune older best checkpoints per policy
+                    try:
+                        _prune_best_ckpts(
+                            local_outdir=state["local_outdir"],
+                            log=log,
+                            keep_k=best_ckpt_keep_k,
+                            retention_secs=best_ckpt_retention_secs,
+                            now=time.time(),
+                        )
+                    except Exception as e:
+                        log.warning(f"[ckpt] best prune error: {e}")
+
+                    log.info(f"[ckpt] new best: val_loss={best_val_loss:.4f} at step={step}")
+
+                model.train()
+
+            # Step-based checkpointing
+            if save_every > 0 and step % save_every == 0:
+                _save_ckpt(ckptio, state, step, filename=f"ckpt_step_{step}.pt", log=log)
+                # Prune older step checkpoints per policy (age &/or count)
+                try:
+                    _prune_step_ckpts(
+                        local_outdir=state["local_outdir"],
+                        log=log,
+                        retention_secs=step_ckpt_retention_secs,
+                        keep_k=step_ckpt_keep_k,
+                        now=time.time(),
+                    )
+                except Exception as e:
+                    log.warning(f"[ckpt] step prune error: {e}")
+
+            # Time-based checkpointing (e.g., every 30–60 minutes)
+            now_ts = time.time()
+            if last_time_ckpt_ts == 0.0:
+                last_time_ckpt_ts = start_time
+            if time_ckpt_secs > 0 and (now_ts - last_time_ckpt_ts) >= time_ckpt_secs:
+                ts = int(now_ts)
+                fname = f"ckpt_time_{ts}.pt"
+                _save_ckpt(ckptio, state, step, filename=fname, log=log)
+                last_time_ckpt_ts = now_ts
+                state["last_time_ckpt_ts"] = last_time_ckpt_ts  # persist within this run
+
+                # Prune older time-based checkpoints to save disk
+                try:
+                    _prune_time_ckpts(
+                        local_outdir=state["local_outdir"],
+                        log=log,
+                        retention_secs=time_ckpt_retention_secs,
+                        keep_k=time_ckpt_keep_k,
+                        now=now_ts,
+                    )
+                except Exception as e:
+                    log.warning(f"[ckpt] time prune error: {e}")
+
+            if step >= total_steps:
+                break
+
+    # Persist best loss to state (helpful if caller saves run metadata)
+    state["best_val_loss"] = best_val_loss
+    return step

--- a/vertex/package/liquid_llm_vertex_full/src/liquid_llm/training/stage0.py
+++ b/vertex/package/liquid_llm_vertex_full/src/liquid_llm/training/stage0.py
@@ -1,0 +1,203 @@
+import os
+import random
+from pathlib import Path
+from datetime import datetime
+
+import numpy as np
+import torch
+
+from transformers import AutoTokenizer  # (kept if other modules rely on it)
+
+from ..data.wikitext import build_dataloaders
+from ..models.liquid import build_student_model
+from ..training.optim import build_optimizer
+from ..training.schedules import build_scheduler
+from ..training.loop import train_loop
+from ..utils.logging import get_logger
+from ..io.checkpoints import load_from_uri, save_and_maybe_upload
+
+
+def _expand_output_uri(output_gcs_uri: str | None) -> str | None:
+    """
+    Vertex passes job args directly to Python, so any shell substitutions
+    like $(date ...) won't expand. Handle common patterns here, and also
+    create a sensible default path if None is provided.
+    """
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+    if output_gcs_uri:
+        # Replace a common shell placeholder if present
+        if "$(" in output_gcs_uri:
+            output_gcs_uri = output_gcs_uri.replace("$(date +%Y%m%d-%H%M%S)", ts)
+        return output_gcs_uri
+
+    # If not provided, default to a timestamped run folder under the bucket.
+    # Adjust the base prefix to your preference.
+    return f"gs://liquid-llm-bucket/liquid-llm/stage0/checkpoints/vertex_runs/{ts}"
+
+
+def run_training(
+    resume_gcs_uri: str | None,
+    block_size: int,
+    teacher_name: str,
+    dataset_name: str,
+    dataset_config: str,
+    output_gcs_uri: str | None = None,
+    local_workdir: str = "/tmp/liquid_work",
+    seed: int = 42,
+    global_batch: int = 64,
+    micro_batch: int = 8,
+    lr: float = 3e-4,
+    weight_decay: float = 0.1,
+    betas=(0.9, 0.95),
+    eps: float = 1e-8,
+    warmup_steps: int = 2000,
+    train_steps: int = 45000,
+    eval_every: int = 500,
+    save_every: int = 1000,
+    log_interval: int = 50,
+    grad_clip: float | None = 1.0,
+    kd_alpha: float | None = 0.5,
+    kd_temperature: float | None = 1.0,
+    time_ckpt_secs: int | None = 1800,
+    time_ckpt_retention_secs: int | None = 14400,
+    time_ckpt_keep_k: int | None = None,
+    best_ckpt_keep_k: int | None = 3,
+    best_ckpt_retention_secs: int | None = None,
+    step_ckpt_keep_k: int | None = 5,
+    step_ckpt_retention_secs: int | None = None,
+    precision: str = "fp16",
+    model: dict = None,
+):
+    log = get_logger("stage0")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    # ---------------------------------------------------------------------
+    # Seeding
+    # ---------------------------------------------------------------------
+    torch.manual_seed(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    # ---------------------------------------------------------------------
+    # Data
+    # ---------------------------------------------------------------------
+    train_dl, val_dl, vocab_size, pad_id, tok = build_dataloaders(
+        teacher_name=teacher_name,
+        dataset_name=dataset_name,
+        dataset_config=dataset_config,
+        block_size=block_size,
+        global_batch=global_batch,
+        seed=seed,
+    )
+
+    # ---------------------------------------------------------------------
+    # Model
+    # ---------------------------------------------------------------------
+    model = model or {}
+    margs = dict(
+        d_model=model.get("d_model", 768),
+        n_layers=model.get("n_layers", 10),
+        n_heads=model.get("n_heads", 12),
+        dropout=model.get("dropout", 0.0),
+    )
+    student = build_student_model(
+        vocab_size=vocab_size,
+        pad_id=pad_id,
+        **margs,
+    ).to(device)
+
+    # ---------------------------------------------------------------------
+    # Optimizer / Scheduler
+    # ---------------------------------------------------------------------
+    optimizer = build_optimizer(
+        student, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps
+    )
+    scheduler = build_scheduler(
+        optimizer, warmup_steps=warmup_steps, total_steps=train_steps
+    )
+
+    # ---------------------------------------------------------------------
+    # Resume (optional)
+    # ---------------------------------------------------------------------
+    step0 = 0
+    if resume_gcs_uri:
+        try:
+            step0 = load_from_uri(student, optimizer, scheduler, resume_gcs_uri)
+            log.info(f"Resumed from {resume_gcs_uri} at step {step0}")
+        except Exception as e:
+            log.warning(f"Resume failed: {e}")
+
+    # ---------------------------------------------------------------------
+    # Outputs
+    # ---------------------------------------------------------------------
+    local_outdir = Path(local_workdir) / "outputs"
+    local_outdir.mkdir(parents=True, exist_ok=True)
+    gcs_outdir = _expand_output_uri(output_gcs_uri)
+    if gcs_outdir:
+        log.info(f"Writing checkpoints to {gcs_outdir}")
+
+    # ---------------------------------------------------------------------
+    # Training state
+    #   NOTE: train_loop expects `state['log']` to be a logger with .info()
+    #         Keep custom bookkeeping in `log_state`.
+    # ---------------------------------------------------------------------
+    state = dict(
+        model=student,
+        device=device,
+        teacher_name=teacher_name,
+        train_loader=train_dl,
+        val_loader=val_dl,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        save_every=save_every,
+        eval_every=eval_every,
+        log_interval=log_interval,
+        train_steps=train_steps,
+        output_prefix="",
+        ckptio=save_and_maybe_upload,
+        local_outdir=str(local_outdir),
+        gcs_outdir=gcs_outdir,
+        precision=precision,
+        step=step0,
+        micro_batch=micro_batch,
+        global_batch=global_batch,
+        grad_clip=grad_clip,
+        kd_alpha=kd_alpha,
+        kd_temperature=kd_temperature,
+        time_ckpt_secs=time_ckpt_secs,
+        time_ckpt_retention_secs=time_ckpt_retention_secs,
+        time_ckpt_keep_k=time_ckpt_keep_k,
+        best_ckpt_keep_k=best_ckpt_keep_k,
+        best_ckpt_retention_secs=best_ckpt_retention_secs,
+        step_ckpt_keep_k=step_ckpt_keep_k,
+        step_ckpt_retention_secs=step_ckpt_retention_secs,
+        # logger used by train_loop
+        log=get_logger("train"),
+        # optional bookkeeping for your own use
+        log_state={
+            "history": [],
+            "last_eval": None,
+            "running_loss": None,
+        },
+    )
+
+    # ---------------------------------------------------------------------
+    # Train
+    # ---------------------------------------------------------------------
+    final_step = train_loop(state)
+
+    # ---------------------------------------------------------------------
+    # Final save
+    # ---------------------------------------------------------------------
+    sd = {
+        "model": student.state_dict(),
+        "optimizer": optimizer.state_dict(),
+        "scheduler": scheduler.state_dict(),
+        "step": final_step,
+        "tokenizer": getattr(tok, "name_or_path", None),
+    }
+    save_and_maybe_upload(sd, local_outdir, gcs_outdir, filename="final.pt")
+    log.info(f"Finished at step {final_step}.")

--- a/vertex/package/liquid_llm_vertex_full/src/trainer/args.py
+++ b/vertex/package/liquid_llm_vertex_full/src/trainer/args.py
@@ -1,0 +1,118 @@
+import argparse, yaml, os
+from pathlib import Path
+
+def get_parser():
+    p = argparse.ArgumentParser(description="Liquid‑LLM Stage0 Vertex launcher")
+    # Required-ish (as used in your run)
+    p.add_argument('--resume_gcs_uri', type=str, default=None)
+    p.add_argument('--block_size', type=int, required=True)
+    p.add_argument('--teacher_name', type=str, required=True)
+    p.add_argument('--dataset_name', type=str, required=True)
+    p.add_argument('--dataset_config', type=str, required=True)
+
+    # Outputs
+    p.add_argument('--output_gcs_uri', type=str, default=None)
+    p.add_argument('--local_workdir', type=str, default='/tmp/liquid_work')
+
+    # Hyperparams / training knobs
+    p.add_argument('--config', type=str, default=None, help='YAML file to merge as defaults')
+    p.add_argument('--seed', type=int, default=None)
+    p.add_argument('--global_batch', type=int, default=None)
+    p.add_argument('--micro_batch', type=int, default=None)
+    p.add_argument('--lr', type=float, default=None)
+    p.add_argument('--weight_decay', type=float, default=None)
+    p.add_argument('--betas', type=float, nargs=2, default=None)
+    p.add_argument('--eps', type=float, default=None)
+    p.add_argument('--warmup_steps', type=int, default=None)
+    p.add_argument('--train_steps', type=int, default=None)
+    p.add_argument('--eval_every', type=int, default=None)
+    p.add_argument('--teacher_eval_every', type=int, default=None)
+    p.add_argument('--save_every', type=int, default=None)
+    p.add_argument('--log_interval', type=int, default=None)
+    p.add_argument('--grad_clip', type=float, default=None)
+    p.add_argument('--kd_alpha', type=float, default=None)
+    p.add_argument('--kd_temperature', type=float, default=None)
+    p.add_argument('--time_ckpt_secs', type=int, default=None)
+    p.add_argument('--time_ckpt_retention_secs', type=int, default=None)
+    p.add_argument('--time_ckpt_keep_k', type=int, default=None)
+    p.add_argument('--best_ckpt_keep_k', type=int, default=None)
+    p.add_argument('--best_ckpt_retention_secs', type=int, default=None)
+    p.add_argument('--step_ckpt_keep_k', type=int, default=None)
+    p.add_argument('--step_ckpt_retention_secs', type=int, default=None)
+    p.add_argument('--fp16', action='store_true')
+    p.add_argument('--bf16', action='store_true')
+
+    # Model
+    p.add_argument('--d_model', type=int, default=None)
+    p.add_argument('--n_layers', type=int, default=None)
+    p.add_argument('--n_heads', type=int, default=None)
+    p.add_argument('--dropout', type=float, default=None)
+
+    return p
+
+def parse_args(argv=None):
+    p = get_parser()
+    args = p.parse_args(argv)
+
+    # Merge config file if provided
+    merged = {}
+    if args.config:
+        with open(args.config, 'r') as f:
+            merged = yaml.safe_load(f) or {}
+
+    # CLI overrides config
+    def o(name, default=None):
+        v = getattr(args, name, None)
+        return default if v is None else v
+
+    betas = o('betas', merged.get('betas', [0.9, 0.95]))
+    if betas is not None:
+        betas = list(betas)
+
+    model_cfg = merged.get('model') or {}
+
+    teacher_eval_every = o('teacher_eval_every', merged.get('teacher_eval_every'))
+    eval_every_default = merged.get('eval_every', 500)
+    eval_every = o('eval_every', eval_every_default)
+    if teacher_eval_every is not None:
+        eval_every = teacher_eval_every
+
+    cfg = {
+        'resume_gcs_uri': args.resume_gcs_uri,
+        'block_size': args.block_size,
+        'teacher_name': args.teacher_name,
+        'dataset_name': args.dataset_name,
+        'dataset_config': args.dataset_config,
+        'output_gcs_uri': args.output_gcs_uri,
+        'local_workdir': args.local_workdir,
+        'seed': o('seed', merged.get('seed', 42)),
+        'global_batch': o('global_batch', merged.get('global_batch', 64)),
+        'micro_batch': o('micro_batch', merged.get('micro_batch', 8)),
+        'lr': o('lr', merged.get('lr', 3e-4)),
+        'weight_decay': o('weight_decay', merged.get('weight_decay', 0.1)),
+        'betas': betas,
+        'eps': o('eps', merged.get('eps', 1e-8)),
+        'warmup_steps': o('warmup_steps', merged.get('warmup_steps', 2000)),
+        'train_steps': o('train_steps', merged.get('train_steps', 10000)),
+        'eval_every': eval_every,
+        'save_every': o('save_every', merged.get('save_every', 1000)),
+        'log_interval': o('log_interval', merged.get('log_interval', 50)),
+        'grad_clip': o('grad_clip', merged.get('grad_clip', 1.0)),
+        'kd_alpha': o('kd_alpha', merged.get('kd_alpha', 0.5)),
+        'kd_temperature': o('kd_temperature', merged.get('kd_temperature', 1.0)),
+        'time_ckpt_secs': o('time_ckpt_secs', merged.get('time_ckpt_secs', 1800)),
+        'time_ckpt_retention_secs': o('time_ckpt_retention_secs', merged.get('time_ckpt_retention_secs', 14400)),
+        'time_ckpt_keep_k': o('time_ckpt_keep_k', merged.get('time_ckpt_keep_k', None)),
+        'best_ckpt_keep_k': o('best_ckpt_keep_k', merged.get('best_ckpt_keep_k', 3)),
+        'best_ckpt_retention_secs': o('best_ckpt_retention_secs', merged.get('best_ckpt_retention_secs', None)),
+        'step_ckpt_keep_k': o('step_ckpt_keep_k', merged.get('step_ckpt_keep_k', 5)),
+        'step_ckpt_retention_secs': o('step_ckpt_retention_secs', merged.get('step_ckpt_retention_secs', None)),
+        'precision': 'bf16' if args.bf16 else ('fp16' if args.fp16 else 'no'),
+        'model': {
+            'd_model': o('d_model', model_cfg.get('d_model', 768)),
+            'n_layers': o('n_layers', model_cfg.get('n_layers', 10)),
+            'n_heads': o('n_heads', model_cfg.get('n_heads', 12)),
+            'dropout': o('dropout', model_cfg.get('dropout', 0.0)),
+        }
+    }
+    return cfg


### PR DESCRIPTION
## Summary
- register Vertex-provided CLI flags for gradient clipping, knowledge distillation, and checkpoint retention
- map `teacher_eval_every` to the evaluation cadence while keeping YAML overrides JSON-serialisable
- thread the new options through the stage0 training entrypoint and loop, applying KD temperature and configurable grad clipping

## Testing
- python -m compileall vertex/package/liquid_llm_vertex_full/src

------
https://chatgpt.com/codex/tasks/task_e_68e35293ffc8832194e5de60f366bf84