### PR TITLE
Ensure Vertex trainer can access HF secret with scoped credentials

### DIFF
--- a/vertex/package/liquid_llm_vertex_full/src/liquid_llm/training/stage0.py
+++ b/vertex/package/liquid_llm_vertex_full/src/liquid_llm/training/stage0.py
@@ -59,9 +59,13 @@ def run_training(
     precision: str = "fp16",
     model: dict = None,
     hf_token: str | None = None,
+    hf_secret_name: str | None = None,
 ):
     log = get_logger("stage0")
     device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    if hf_secret_name:
+        log.info(f"Using Hugging Face token from secret '{hf_secret_name}'.")
 
     # ---------------------------------------------------------------------
     # Seeding

--- a/vertex/package/liquid_llm_vertex_full/src/trainer/args.py
+++ b/vertex/package/liquid_llm_vertex_full/src/trainer/args.py
@@ -9,6 +9,8 @@ def get_parser():
     p.add_argument('--teacher_name', type=str, required=True)
     p.add_argument('--dataset_name', type=str, required=True)
     p.add_argument('--dataset_config', type=str, required=True)
+    p.add_argument('--hf_secret_name', type=str, default=None,
+                   help='Secret Manager name containing the Hugging Face token')
 
     # Outputs
     p.add_argument('--output_gcs_uri', type=str, default=None)
@@ -62,6 +64,7 @@ def parse_args(argv=None):
         'dataset_config': args.dataset_config,
         'output_gcs_uri': args.output_gcs_uri,
         'local_workdir': args.local_workdir,
+        'hf_secret_name': o('hf_secret_name', merged.get('hf_secret_name')),
         'seed': o('seed', merged.get('seed', 42)),
         'global_batch': o('global_batch', merged.get('global_batch', 64)),
         'micro_batch': o('micro_batch', merged.get('micro_batch', 8)),

--- a/vertex/package/liquid_llm_vertex_full/src/trainer/entrypoint.py
+++ b/vertex/package/liquid_llm_vertex_full/src/trainer/entrypoint.py
@@ -16,7 +16,10 @@ def main(argv=None):
     log.info(f"Parsed config: {cfg}")
     set_all_seeds(cfg['seed'])
 
-    hf_token = ensure_hf_token(log=log)
+    secret_names = None
+    if cfg.get('hf_secret_name'):
+        secret_names = [cfg['hf_secret_name']]
+    hf_token = ensure_hf_token(secret_names=secret_names, log=log)
     cfg['hf_token'] = hf_token
 
     run_training(**cfg)

--- a/vertex/package/liquid_llm_vertex_full/src/trainer/secrets.py
+++ b/vertex/package/liquid_llm_vertex_full/src/trainer/secrets.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import os
 from typing import Iterable, Optional
 
+import google.auth
+from google.api_core import exceptions as gcloud_exceptions
+from google.auth import exceptions as auth_exceptions
 from google.cloud import secretmanager
 
 
@@ -18,6 +21,9 @@ _PROJECT_ENV_VARS: Iterable[str] = (
 )
 
 
+_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+
 def _detect_project_id() -> Optional[str]:
     """Best effort detection of the active Google Cloud project ID/number."""
 
@@ -28,9 +34,30 @@ def _detect_project_id() -> Optional[str]:
     return None
 
 
+def _build_secret_client(log=None):
+    """Construct a Secret Manager client with cloud-platform scope if possible."""
+
+    credentials = None
+    project_from_creds: Optional[str] = None
+    try:
+        credentials, project_from_creds = google.auth.default(scopes=(_CLOUD_PLATFORM_SCOPE,))
+    except auth_exceptions.DefaultCredentialsError as exc:
+        if log:
+            log.warning("Unable to load default Google credentials: %s", exc)
+
+    client = (
+        secretmanager.SecretManagerServiceClient(credentials=credentials)
+        if credentials is not None
+        else secretmanager.SecretManagerServiceClient()
+    )
+
+    return client, project_from_creds
+
+
 def ensure_hf_token(
     *,
     secret_name: str = "hf-token",
+    secret_names: Optional[Iterable[str]] = None,
     env_var: str = "HUGGING_FACE_HUB_TOKEN",
     log=None,
 ) -> str:
@@ -39,10 +66,11 @@ def ensure_hf_token(
     The precedence order is:
 
     1. Existing environment variables (``HUGGING_FACE_HUB_TOKEN``/``HF_TOKEN``)
-    2. Google Secret Manager secret ``secret_name`` in the active project
+    2. Google Secret Manager secrets in ``secret_names``/``secret_name`` order
 
     Args:
-        secret_name: Secret Manager identifier containing the HF access token.
+        secret_name: Default Secret Manager identifier containing the HF access token.
+        secret_names: Optional iterable of secret names to try (in order).
         env_var: Environment variable name to populate with the token.
         log: Optional logger with an ``info``/``warning`` method.
 
@@ -60,38 +88,70 @@ def ensure_hf_token(
             log.info("Using Hugging Face token from environment variable.")
         return token
 
-    project_id = _detect_project_id()
+    client, project_from_creds = _build_secret_client(log=log)
+
+    project_id = _detect_project_id() or project_from_creds
+    if log and project_from_creds and project_id == project_from_creds:
+        log.info("Resolved Google Cloud project from application default credentials: %s", project_id)
     if not project_id:
         raise RuntimeError(
             "Unable to determine Google Cloud project for Secret Manager. "
             "Set the HUGGING_FACE_HUB_TOKEN environment variable or configure project metadata."
         )
 
-    client = secretmanager.SecretManagerServiceClient()
-    name = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
+    candidates = list(secret_names or ())
+    if not candidates:
+        candidates.append(secret_name)
+    else:
+        # maintain backwards compatibility with the legacy default name if a
+        # single override was supplied.
+        if len(candidates) == 1 and candidates[0] in {"hf-token", "hf_token"}:
+            alt = "hf-token" if candidates[0] == "hf_token" else "hf_token"
+            candidates.append(alt)
 
-    try:
-        response = client.access_secret_version(name=name)
-    except Exception as exc:  # pragma: no cover - bubble up with context
-        raise RuntimeError(
-            f"Failed to access secret '{secret_name}' in project '{project_id}': {exc}"
-        ) from exc
+    # Ensure the default names are always attempted if not explicitly provided.
+    for fallback in ("hf_token", "hf-token"):
+        if fallback not in candidates:
+            candidates.append(fallback)
 
-    token = response.payload.data.decode("utf-8").strip()
-    if not token:
-        raise RuntimeError(
-            f"Secret '{secret_name}' in project '{project_id}' is empty."
-        )
+    errors = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        name = f"projects/{project_id}/secrets/{candidate}/versions/latest"
+        try:
+            response = client.access_secret_version(name=name)
+        except Exception as exc:  # pragma: no cover - bubble up with context
+            if log and isinstance(exc, gcloud_exceptions.PermissionDenied):
+                log.error(
+                    "Permission denied when accessing secret '%s'. Ensure the Vertex AI service "
+                    "account has Secret Manager Secret Accessor roles and the VM has the "
+                    "cloud-platform OAuth scope.",
+                    candidate,
+                )
+            errors.append((candidate, exc))
+            continue
 
-    os.environ[env_var] = token
-    os.environ.setdefault("HF_TOKEN", token)
+        token = response.payload.data.decode("utf-8").strip()
+        if not token:
+            errors.append((candidate, ValueError("secret payload empty")))
+            continue
 
-    if log:
-        log.info(
-            "Loaded Hugging Face token from Secret Manager secret '%s' (project '%s').",
-            secret_name,
-            project_id,
-        )
+        os.environ[env_var] = token
+        os.environ.setdefault("HF_TOKEN", token)
 
-    return token
+        if log:
+            log.info(
+                "Loaded Hugging Face token from Secret Manager secret '%s' (project '%s').",
+                candidate,
+                project_id,
+            )
+
+        return token
+
+    details = ", ".join(f"{name}: {err}" for name, err in errors) or "no candidates"
+    raise RuntimeError(
+        "Failed to access any configured Hugging Face token secret. "
+        f"Tried: {', '.join(candidates)} (details: {details})"
+    )
 

--- a/vertex/package/liquid_llm_vertex_full/vertex_args.txt
+++ b/vertex/package/liquid_llm_vertex_full/vertex_args.txt
@@ -1,0 +1,8 @@
+--resume_gcs_uri=gs://liquid-llm-bucket/liquid-llm/stage0/checkpoints/step_68150_20250919-034436_best_174.72.pt
+--block_size=512
+--teacher_name=gpt2-xl
+--dataset_name=wikitext
+--dataset_config=wikitext-103-raw-v1
+--output_gcs_uri=gs://liquid-llm-bucket/liquid-llm/stage0/checkpoints/vertex_runs/$(date +%Y%m%d-%H%M%S)
+--train_steps=1000000
+--hf_secret_name=hf_token


### PR DESCRIPTION
## Summary
- request application default credentials with the cloud-platform scope before constructing the Secret Manager client
- reuse the scoped client while resolving HF token secrets and log when the project ID comes from ADC
- emit a targeted error message when Secret Manager denies access so Vertex setup issues are obvious

## Testing
- python -m compileall vertex/package/liquid_llm_vertex_full/src

------
https://chatgpt.com/codex/tasks/task_e_68e40855f0c4832185d47023a7f78563