### PR TITLE
Support alternative Hugging Face token inputs

### DIFF
--- a/vertex/package/liquid_llm_vertex_full/README.md
+++ b/vertex/package/liquid_llm_vertex_full/README.md
@@ -13,3 +13,43 @@ gsutil cp dist/liquid_llm_vertex-0.0.1-py3-none-any.whl gs://liquid-llm-bucket/v
 ## Run (Vertex)
 
 Set `python_module=trainer.entrypoint` and `package_uris=["gs://liquid-llm-bucket/vertex_pkg.whl"]`.
+
+## Troubleshooting
+
+### Hugging Face token failures
+
+The training entrypoint resolves the Hugging Face token in the following order:
+
+1. `HUGGING_FACE_HUB_TOKEN` / `HF_TOKEN` environment variables already present on the worker.
+2. A token supplied explicitly via `--hf_token`, `--hf_token_file`, or
+   `--hf_token_gcs_uri`.
+3. Secrets fetched from Secret Manager using the names supplied via
+   `--hf_secret_name` (defaulting to `hf-token`) and the built-in fallbacks
+   `hf_token` and `hf-token`.
+
+If none of those lookups succeed the job will exit with an error similar to:
+
+```
+RuntimeError: Failed to access any configured Hugging Face token secret. Tried: hf_token, hf-token (details: ... ACCESS_TOKEN_SCOPE_INSUFFICIENT ...)
+```
+
+This indicates the Vertex AI service account or VM scopes cannot access the
+Secret Manager secret. To resolve the issue:
+
+* Grant the Vertex AI custom training service account the **Secret Manager
+  Secret Accessor** role on the relevant secret (or the project containing it).
+* Ensure the worker pool has the `cloud-platform` OAuth scope. When launching
+  jobs via the API, include
+ `worker_pool_specs[*].machine_spec.service_account` (if using a custom service
+  account).
+* If the service account cannot read from Secret Manager, provide the token via
+  `worker_pool_specs[*].container_spec.env` or by referencing a file using
+  `--hf_token_file` / `--hf_token_gcs_uri`.
+
+When using the CLI flags directly, prefer `--hf_token_file` or
+`--hf_token_gcs_uri` so that the token can be managed outside of command-line
+arguments. The direct `--hf_token` flag is available for completeness but should
+only be used for short-lived experiments.
+
+After permissions are in place, retry the job or provide the token via
+environment variables.

--- a/vertex/package/liquid_llm_vertex_full/src/trainer/args.py
+++ b/vertex/package/liquid_llm_vertex_full/src/trainer/args.py
@@ -11,6 +11,12 @@ def get_parser():
     p.add_argument('--dataset_config', type=str, required=True)
     p.add_argument('--hf_secret_name', type=str, default=None,
                    help='Secret Manager name containing the Hugging Face token')
+    p.add_argument('--hf_token', type=str, default=None,
+                   help='Direct Hugging Face token value (use Secret Manager when possible)')
+    p.add_argument('--hf_token_file', type=str, default=None,
+                   help='Local path to a file containing the Hugging Face token')
+    p.add_argument('--hf_token_gcs_uri', type=str, default=None,
+                   help='GCS URI to a file containing the Hugging Face token')
 
     # Outputs
     p.add_argument('--output_gcs_uri', type=str, default=None)
@@ -65,6 +71,9 @@ def parse_args(argv=None):
         'output_gcs_uri': args.output_gcs_uri,
         'local_workdir': args.local_workdir,
         'hf_secret_name': o('hf_secret_name', merged.get('hf_secret_name')),
+        'hf_token_value': o('hf_token', merged.get('hf_token_value')),
+        'hf_token_file': o('hf_token_file', merged.get('hf_token_file')),
+        'hf_token_gcs_uri': o('hf_token_gcs_uri', merged.get('hf_token_gcs_uri')),
         'seed': o('seed', merged.get('seed', 42)),
         'global_batch': o('global_batch', merged.get('global_batch', 64)),
         'micro_batch': o('micro_batch', merged.get('micro_batch', 8)),


### PR DESCRIPTION
## Summary
- allow the Vertex trainer CLI to accept Hugging Face tokens via direct value, local file, or GCS URI
- extend the token loader to read from those sources, redact sensitive logging, and keep Secret Manager as a fallback
- document the new token sourcing options and updated remediation guidance in the package README

## Testing
- python -m compileall vertex/package/liquid_llm_vertex_full/src/trainer

------
https://chatgpt.com/codex/tasks/task_e_68e457410d3483219003ca710bafcc2d