### PR TITLE
Handle missing Hugging Face token on Vertex

### DIFF
--- a/vertex/package/liquid_llm_vertex_pkg_3/src/trainer/args.py
+++ b/vertex/package/liquid_llm_vertex_pkg_3/src/trainer/args.py
@@ -17,6 +17,8 @@ def get_parser():
                    help='Path to a file containing the Hugging Face token')
     p.add_argument('--hf_token_gcs_uri', type=str, default=None,
                    help='GCS URI to a file containing the Hugging Face token')
+    p.add_argument('--require_hf_token', action='store_true',
+                   help='Fail if a Hugging Face token cannot be resolved')
 
     # Outputs
     p.add_argument('--output_gcs_uri', type=str, default=None)
@@ -62,6 +64,10 @@ def parse_args(argv=None):
         v = getattr(args, name, None)
         return default if v is None else v
 
+    require_hf_token = bool(merged.get('require_hf_token', False))
+    if args.require_hf_token:
+        require_hf_token = True
+
     cfg = {
         'resume_gcs_uri': args.resume_gcs_uri,
         'block_size': args.block_size,
@@ -74,6 +80,7 @@ def parse_args(argv=None):
         'hf_token_value': o('hf_token_value', merged.get('hf_token_value')),
         'hf_token_file': o('hf_token_file', merged.get('hf_token_file')),
         'hf_token_gcs_uri': o('hf_token_gcs_uri', merged.get('hf_token_gcs_uri')),
+        'require_hf_token': require_hf_token,
         'seed': o('seed', merged.get('seed', 42)),
         'global_batch': o('global_batch', merged.get('global_batch', 64)),
         'micro_batch': o('micro_batch', merged.get('micro_batch', 8)),

--- a/vertex/package/liquid_llm_vertex_pkg_3/src/trainer/entrypoint.py
+++ b/vertex/package/liquid_llm_vertex_pkg_3/src/trainer/entrypoint.py
@@ -25,7 +25,13 @@ def main(argv=None):
     secret_names = None
     if cfg.get('hf_secret_name'):
         secret_names = [cfg['hf_secret_name']]
-    hf_token = ensure_hf_token(secret_names=secret_names, log=log, **token_kwargs)
+    require_hf_token = cfg.pop('require_hf_token', False)
+    hf_token = ensure_hf_token(
+        secret_names=secret_names,
+        log=log,
+        allow_missing=not require_hf_token,
+        **token_kwargs,
+    )
     cfg['hf_token'] = hf_token
 
     run_training(**cfg)

--- a/vertex/package/liquid_llm_vertex_pkg_3/src/trainer/secrets.py
+++ b/vertex/package/liquid_llm_vertex_pkg_3/src/trainer/secrets.py
@@ -53,8 +53,9 @@ def ensure_hf_token(
     token_file: Optional[str] = None,
     token_gcs_uri: Optional[str] = None,
     storage_client: Optional[storage.Client] = None,
+    allow_missing: bool = False,
     log=None,
-) -> str:
+) -> Optional[str]:
     """Ensure a Hugging Face token is available via env vars.
 
     The precedence order is:
@@ -72,7 +73,8 @@ def ensure_hf_token(
         log: Optional logger with an ``info``/``warning`` method.
 
     Returns:
-        The Hugging Face token string.
+        The Hugging Face token string if one could be resolved, otherwise
+        ``None`` when ``allow_missing`` is True.
 
     Raises:
         RuntimeError: If the token cannot be resolved.
@@ -175,6 +177,15 @@ def ensure_hf_token(
             return token
 
     details = ", ".join(f"{name}: {err}" for name, err in errors) or "no candidates"
+    if allow_missing:
+        if log:
+            log.warning(
+                "Failed to resolve a Hugging Face token from any configured "
+                "source; continuing without one. Attempts: %s",
+                details,
+            )
+        return None
+
     raise RuntimeError(
         "Failed to resolve a Hugging Face token from any configured source. "
         f"Attempts: {details}"


### PR DESCRIPTION
## Summary
- add a --require_hf_token flag so jobs can opt into failing when no Hugging Face token is available
- allow ensure_hf_token to continue without a token when permitted and surface a warning instead of raising
- plumb the relaxed behaviour through the Vertex trainer entrypoint

## Testing
- python -m compileall vertex/package/liquid_llm_vertex_pkg_3/src

------
https://chatgpt.com/codex/tasks/task_e_68e4670328988321be464b942d37350b