### PR TITLE
Ensure KD aborts when teacher fails

### DIFF
--- a/vertex/package/liquid_llm_vertex_pkg_3/src/liquid_llm/training/evaluation.py
+++ b/vertex/package/liquid_llm_vertex_pkg_3/src/liquid_llm/training/evaluation.py
@@ -1,15 +1,27 @@
 import torch
-from .metrics import cross_entropy, Meter
+
+from .metrics import Meter, cross_entropy
+
+
+def _extract_logits(output):
+    """Return tensor logits from either an HF output struct or raw tensor."""
+    if hasattr(output, "logits"):
+        return output.logits
+    return output
+
 
 @torch.no_grad()
-def evaluate(model, val_loader, device='cuda'):
+def evaluate(model, val_loader, device: str = "cuda"):
+    was_training = model.training
     model.eval()
     meter = Meter()
     for batch in val_loader:
-        input_ids = batch['input_ids'].to(device)
-        labels = batch['labels'].to(device)
-        logits = model(input_ids)
+        input_ids = batch["input_ids"].to(device)
+        labels = batch["labels"].to(device)
+        output = model(input_ids)
+        logits = _extract_logits(output)
         loss = cross_entropy(logits, labels)
         meter.update(loss.item(), k=input_ids.size(0))
-    model.train()
-    return {'val_loss': meter.avg, 'val_ppl': float(torch.exp(torch.tensor(meter.avg)))}
+    if was_training:
+        model.train()
+    return {"val_loss": meter.avg, "val_ppl": float(torch.exp(torch.tensor(meter.avg)))}


### PR DESCRIPTION
## Summary
- guard the training loop so knowledge distillation aborts when the teacher model cannot be loaded or evaluated
- improve evaluation to handle HuggingFace model outputs and restore the model's original train/eval state while logging teacher metrics

## Testing
- python -m compileall vertex/package/liquid_llm_vertex_pkg_3/src

------
https://chatgpt.com/codex/tasks/task_e_68e474bbb89c8321a980bc8044583df0