### PR TITLE
Ensure best checkpoints upload to GCS

### DIFF
--- a/vertex/package/liquid_llm_vertex_pkg_4/src/liquid_llm/training/stage0.py
+++ b/vertex/package/liquid_llm_vertex_pkg_4/src/liquid_llm/training/stage0.py
@@ -191,5 +191,21 @@ def run_training(
         "step": final_step,
         "tokenizer": getattr(tok, "name_or_path", None),
     }
-    save_and_maybe_upload(sd, local_outdir, gcs_outdir, filename="final.pt")
+    final_local, final_uri = save_and_maybe_upload(
+        sd, local_outdir, gcs_outdir, filename="final.pt"
+    )
+    if gcs_outdir and not final_uri:
+        log.warning(
+            "[ckpt] expected to upload final checkpoint to %s but no URI was returned",
+            gcs_outdir,
+        )
+    state.setdefault("log_state", {}).update(
+        {
+            "final_checkpoint": {
+                "step": final_step,
+                "local_path": final_local,
+                "gcs_uri": final_uri,
+            }
+        }
+    )
     log.info(f"Finished at step {final_step}.")


### PR DESCRIPTION
## Summary
- return the remote URI from the checkpoint helper so uploads can be tracked
- record GCS metadata for best, versioned, step, and time checkpoints and warn if uploads are missing
- persist the final checkpoint upload details in the training state for downstream consumers

## Testing
- python -m compileall vertex/package/liquid_llm_vertex_pkg_4/src

------
https://chatgpt.com/codex/tasks/task_e_68e4c772a2788321860d611121579698