### PR TITLE
Refine Vertex training telemetry logging

### DIFF
--- a/vertex/package/liquid_llm_vertex_pkg_4/src/trainer/entrypoint.py
+++ b/vertex/package/liquid_llm_vertex_pkg_4/src/trainer/entrypoint.py
@@ -13,10 +13,6 @@ def main(argv=None):
     Path(cfg['local_workdir']).mkdir(parents=True, exist_ok=True)
     init_logger()
     log = get_logger('entrypoint')
-
-    log.info("[sys] TOKENIZERS_PARALLELISM=false")
-
-    log.info(f"Parsed config: {cfg}")
     set_all_seeds(cfg['seed'])
 
     token_kwargs = {


### PR DESCRIPTION
## Summary
- capture run metadata such as git SHA, package version, and run ID when preparing the training state
- compress the training loop logging into concise run/train/eval/ckpt/watchdog records with KD hparam change detection
- drop noisy startup logging from the trainer entrypoint

## Testing
- python -m compileall vertex/package/liquid_llm_vertex_pkg_4/src/liquid_llm/training/loop.py
- python -m compileall vertex/package/liquid_llm_vertex_pkg_4/src/liquid_llm/training/stage0.py vertex/package/liquid_llm_vertex_pkg_4/src/trainer/entrypoint.py

------
https://chatgpt.com/codex/tasks/task_e_68e5447e3b8083219b80b751bc988f74