### PR TITLE
Reduce teacher memory usage with configurable precision

### DIFF
--- a/vertex/package/liquid_llm_vertex_pkg_1024/src/trainer/args.py
+++ b/vertex/package/liquid_llm_vertex_pkg_1024/src/trainer/args.py
@@ -42,6 +42,8 @@ def get_parser():
                    help='Optional peak learning rate to reach at the end of warmup')
     p.add_argument('--fp16', action='store_true')
     p.add_argument('--bf16', action='store_true')
+    p.add_argument('--teacher_precision', type=str, default=None,
+                   help='Precision hint for the teacher model (e.g. fp16, bf16, fp32)')
 
     # Model
     p.add_argument('--d_model', type=int, default=None)
@@ -150,6 +152,7 @@ def parse_args(argv=None):
         'log_interval': o('log_interval', merged.get('log_interval', 50)),
         'lr_peak': o('lr_peak', merged.get('lr_peak')),
         'precision': 'bf16' if args.bf16 else ('fp16' if args.fp16 else 'no'),
+        'teacher_precision': o('teacher_precision', merged.get('teacher_precision')),
         'model': {
             'd_model': o('d_model', merged.get('model', {}).get('d_model', 768)),
             'n_layers': o('n_layers', merged.get('model', {}).get('n_layers', 10)),


### PR DESCRIPTION
## Summary
- add a `--teacher_precision` option and normalize precision defaults before launching training
- load the KD teacher with configurable autocast dtype and reuse that dtype during training and evaluation to shrink GPU footprint
- run evaluation through autocast-aware helpers so student/teacher metrics remain stable while using lower precision

## Testing
- python -m compileall vertex/package/liquid_llm_vertex_pkg_1024/src

------
https://chatgpt.com/codex/tasks/task_e_68e701f202d4832180a9559c4e02c1e7