### PR TITLE
Refine evaluation, checkpointing, and logging for phase-based KD

### DIFF
--- a/vertex/package/liquid_llm_vertex_pkg_1024/src/liquid_llm/training/evaluation.py
+++ b/vertex/package/liquid_llm_vertex_pkg_1024/src/liquid_llm/training/evaluation.py
@@ -51,8 +51,9 @@ def evaluate(model, val_loader, device: str = "cuda", autocast_dtype=None):
     avg_loss = meter.avg if meter.n else 0.0
     ppl = float(torch.exp(torch.tensor(avg_loss))) if total_tokens else float("inf")
     return {
-        "val_loss": avg_loss,
+        "val_ce": avg_loss,
         "val_ppl": ppl,
+        "val_loss": avg_loss,
         "tokens": total_tokens,
         "examples": total_examples,
         "batches": total_batches,

--- a/vertex/package/liquid_llm_vertex_pkg_1024/src/trainer/args.py
+++ b/vertex/package/liquid_llm_vertex_pkg_1024/src/trainer/args.py
@@ -169,7 +169,7 @@ def parse_args(argv=None):
         'reset_optim_on_ctx_change': bool(o('reset_optim_on_ctx_change', merged.get('reset_optim_on_ctx_change', False))),
         'grad_accum': o('grad_accum', merged.get('grad_accum')),
         'rope_scale': o('rope_scale', merged.get('rope_scale')),
-        'save_best_on': o('save_best_on', merged.get('save_best_on', 'val_loss_student')),
+        'save_best_on': o('save_best_on', merged.get('save_best_on', 'val_ppl_student')),
         'save_every_steps': o('save_every_steps', merged.get('save_every_steps', 5000)),
         'schedule_from_zero': bool(o('schedule_from_zero', merged.get('schedule_from_zero', False))),
         'reset_lrsched_on_resume': bool(o('reset_lrsched_on_resume', merged.get('reset_lrsched_on_resume', False))),


### PR DESCRIPTION
## Summary
- compute and log student validation cross-entropy/ppl consistently, keeping teacher metrics separate, and expose detailed train-time KD diagnostics including train perplexity
- harden checkpointing with explicit val_ppl_student monitoring, latest/fallback saves, and richer metadata/state persistence for resumption
- drive temperature annealing via phase indices, record scheduler context (warmup/LR), and surface fallback cadence/defaults through the CLI and stage-0 state

## Testing
- python -m py_compile vertex/package/liquid_llm_vertex_pkg_1024/src/liquid_llm/training/evaluation.py vertex/package/liquid_llm_vertex_pkg_1024/src/liquid_llm/training/loop.py vertex/package/liquid_llm_vertex_pkg_1024/src/liquid_llm/training/stage0.py vertex/package/liquid_llm_vertex_pkg_1024/src/trainer/args.py

------
https://chatgpt.com/codex/tasks/task_e_68e70f787fbc83218737d0e5d559c7b4