### PR TITLE
Add compatibility trainer entrypoint for sanity check package

### DIFF
--- a/vertex/package/sanity_check/README.md
+++ b/vertex/package/sanity_check/README.md
@@ -40,6 +40,10 @@ gcloud ai custom-jobs create \
   --worker-pool-spec=machine-type=g2-standard-8,accelerator-type=NVIDIA_L4,accelerator-count=1,container-image-uri=us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-4.py310:latest,local-package-path=vertex/package/sanity_check,python-module=sanity_check.cli,executor-image-uri=us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-4.py310:latest,args="--checkpoint_gcs_uri=gs://liquid-llm-bucket-2/stage0/checkpoints/vertex_runs/20251009-022648/IMPORTANT/stage0_checkpoints_vertex_runs_20251009-022648_best.pt","--block_size=512","--device=cuda","--dtype=bfloat16","--throughput_tokens=32768","--batch_size=8"
 ```
 
+Existing jobs that still point at `python_module=trainer.entrypoint` do not
+need to be updated.  The package now ships a minimal compatibility module that
+delegates to `sanity_check.cli`, so both launcher styles are supported.
+
 ## Exit Codes
 
 * `0` – all required checks passed

--- a/vertex/package/sanity_check/trainer/__init__.py
+++ b/vertex/package/sanity_check/trainer/__init__.py
@@ -1,0 +1,3 @@
+"""Helper package exposing the Vertex trainer compatibility entrypoint."""
+
+__all__ = []

--- a/vertex/package/sanity_check/trainer/entrypoint.py
+++ b/vertex/package/sanity_check/trainer/entrypoint.py
@@ -1,0 +1,34 @@
+"""Vertex trainer compatibility entrypoint for the sanity-check package.
+
+Vertex AI jobs that were originally configured to launch
+``python -m trainer.entrypoint`` will import this module.  To keep
+backwards compatibility with those job specifications we simply delegate
+all argument parsing and execution to ``sanity_check.cli``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Sequence
+
+from sanity_check import cli
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Delegate to :func:`sanity_check.cli.main`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.  When ``None`` the
+        values from :data:`sys.argv` are used, matching ``python -m``
+        semantics.
+    """
+
+    if argv is None:
+        argv = sys.argv[1:]
+    cli.main(list(argv))
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised in production
+    main()


### PR DESCRIPTION
## Summary
- add a trainer.entrypoint compatibility module so existing Vertex jobs can import the sanity check package
- document that both trainer.entrypoint and sanity_check.cli launchers are supported

## Testing
- PYTHONPATH=vertex/package/sanity_check python -m trainer.entrypoint --help


------
https://chatgpt.com/codex/tasks/task_e_68e7fab967ec83219ffcc2a432fab9c5