### PR TITLE
Prepare Stage-1 Vertex package for post-surgery training

### DIFF
--- a/vertex/package/Stage_1/Stage_1/checkpoints/saver.py
+++ b/vertex/package/Stage_1/Stage_1/checkpoints/saver.py
@@ -11,6 +11,8 @@ import torch
 
 from ..monitoring.logger import StructuredLogger
 from ..utils.io import open_sharded_file
+
+
 class BestCheckpointSaver:
     def __init__(self, output_path: str, metric: str, mode: str = "min", logger: Optional[StructuredLogger] = None):
         self.output_path = output_path

--- a/vertex/package/Stage_1/Stage_1/cli.py
+++ b/vertex/package/Stage_1/Stage_1/cli.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import uuid
 
@@ -16,6 +15,10 @@ def main(argv: list[str] | None = None) -> None:
     config = build_config(args)
     if not config.run_id:
         config.run_id = str(uuid.uuid4())
+    if not config.resume_gcs_uri:
+        raise SystemExit("Stage-1 requires --resume_gcs_uri=gs://.../stage1_surgery_*.pt")
+    if "surgery" not in config.resume_gcs_uri:
+        raise SystemExit("--resume_gcs_uri must reference a post-surgery checkpoint (stage1_surgery_*.pt)")
     if config.output_gcs_uri and not config.output_gcs_uri.startswith("gs://"):
         ensure_output_path(config.output_gcs_uri)
     trainer = Stage1Trainer(config)

--- a/vertex/package/Stage_1/Stage_1/distillation/teacher_llama31_8b.py
+++ b/vertex/package/Stage_1/Stage_1/distillation/teacher_llama31_8b.py
@@ -1,51 +1,149 @@
-"""Teacher wrapper for llama-3.1-8b."""
+"""Teacher wrapper for Meta Llama 3.1 8B used in Stage-1 distillation."""
 
 from __future__ import annotations
 
-import functools
+import json
+import logging
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from typing import Optional
 
 import torch
 
-try:
+try:  # pragma: no cover - optional dependency in runtime container
     from transformers import AutoModelForCausalLM, AutoTokenizer
 except Exception:  # pragma: no cover
     AutoModelForCausalLM = None
     AutoTokenizer = None
 
-from ..utils.secrets import get_secret
+from ..utils.secrets import get_hf_token
+
+
+LOGGER = logging.getLogger("Stage1Teacher")
 
 
 @dataclass
 class TeacherConfig:
-    model_name: str = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    """Configuration for the Stage-1 teacher model."""
+
+    model_id: str = "meta-llama/Meta-Llama-3.1-8B"
     endpoint: Optional[str] = None
     hf_secret_name: Optional[str] = None
+    hf_token: Optional[str] = None
+    hf_cache_dir: Optional[str] = None
     device: str = "cuda"
+    http_timeout: float = 30.0
+    max_batch_size: int = 0
 
 
 class TeacherModel:
+    """Provides batched logits either via HF models or an HTTP endpoint."""
+
     def __init__(self, config: TeacherConfig):
         self.config = config
-        self.model = None
-        self.tokenizer = None
         self.device = torch.device(config.device if torch.cuda.is_available() else "cpu")
-        if config.endpoint:
-            raise NotImplementedError("Remote inference endpoint integration pending")
-        if AutoModelForCausalLM is None:
-            raise ImportError("transformers package required for teacher model")
-        token = get_secret(config.hf_secret_name) if config.hf_secret_name else None
-        auth = {"use_auth_token": token} if token else {}
-        self.tokenizer = AutoTokenizer.from_pretrained(config.model_name, **auth)
-        self.model = AutoModelForCausalLM.from_pretrained(config.model_name, torch_dtype=torch.bfloat16, device_map="auto", **auth)
+        self.dtype = torch.bfloat16 if self.device.type == "cuda" else torch.float32
+        self._endpoint = config.endpoint
+        self._max_batch_size = max(0, int(config.max_batch_size))
+
+        if self._endpoint:
+            LOGGER.info("Using teacher HTTP endpoint", extra={"endpoint": self._endpoint})
+            self.model = None
+            self.tokenizer = None
+            return
+
+        if AutoModelForCausalLM is None or AutoTokenizer is None:
+            raise ImportError("transformers package is required for local teacher inference")
+
+        token = config.hf_token or get_hf_token(config.hf_secret_name)
+        auth_kwargs = {}
+        if token:
+            auth_kwargs["use_auth_token"] = token
+
+        load_kwargs = {
+            "torch_dtype": self.dtype,
+            "device_map": "auto" if self.device.type == "cuda" else None,
+        }
+        if config.hf_cache_dir:
+            load_kwargs["cache_dir"] = config.hf_cache_dir
+
+        self.tokenizer = AutoTokenizer.from_pretrained(config.model_id, **auth_kwargs)
+        self.model = AutoModelForCausalLM.from_pretrained(
+            config.model_id,
+            **auth_kwargs,
+            **load_kwargs,
+        )
+        self.model.requires_grad_(False)
         self.model.eval()
 
+    # ------------------------------------------------------------------
     @torch.no_grad()
-    def logits(self, input_ids: torch.Tensor, attention_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
-        assert self.model is not None
-        outputs = self.model(input_ids=input_ids.to(self.device), attention_mask=attention_mask.to(self.device) if attention_mask is not None else None)
-        return outputs.logits.to(input_ids.device)
+    def logits(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if self._endpoint:
+            return self._logits_via_http(input_ids, attention_mask)
+
+        assert self.model is not None, "Local teacher model was not initialised"
+        model_device = next(self.model.parameters()).device
+        original_device = input_ids.device
+
+        batches = list(_chunk_tensor(input_ids, self._max_batch_size))
+        masks = list(_chunk_tensor(attention_mask, self._max_batch_size)) if attention_mask is not None else [None] * len(batches)
+
+        logits: list[torch.Tensor] = []
+        for batch_ids, batch_mask in zip(batches, masks):
+            batch_ids = batch_ids.to(model_device, non_blocking=True)
+            batch_mask = batch_mask.to(model_device, non_blocking=True) if batch_mask is not None else None
+            outputs = self.model(input_ids=batch_ids, attention_mask=batch_mask)
+            logits.append(outputs.logits.to(original_device, dtype=torch.float32))
+
+        return torch.cat(logits, dim=0)
+
+    # ------------------------------------------------------------------
+    def _logits_via_http(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        payload = {
+            "input_ids": input_ids.cpu().tolist(),
+            "attention_mask": attention_mask.cpu().tolist() if attention_mask is not None else None,
+        }
+        data = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            self._endpoint,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.config.http_timeout) as response:
+                body = response.read().decode("utf-8")
+        except urllib.error.URLError as exc:  # pragma: no cover - network failure path
+            raise RuntimeError(f"Teacher endpoint request failed: {exc}") from exc
+
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Teacher endpoint returned non-JSON response") from exc
+
+        if "logits" not in parsed:
+            raise RuntimeError("Teacher endpoint response missing 'logits' field")
+
+        tensor = torch.tensor(parsed["logits"], dtype=torch.float32)
+        return tensor.to(input_ids.device)
+
+
+def _chunk_tensor(tensor: Optional[torch.Tensor], max_batch_size: int) -> list[torch.Tensor]:
+    if tensor is None:
+        return []
+    if max_batch_size <= 0 or tensor.size(0) <= max_batch_size:
+        return [tensor]
+    return [tensor[idx : idx + max_batch_size] for idx in range(0, tensor.size(0), max_batch_size)]
 
 
 __all__ = ["TeacherModel", "TeacherConfig"]

--- a/vertex/package/Stage_1/Stage_1/models/__init__.py
+++ b/vertex/package/Stage_1/Stage_1/models/__init__.py
@@ -1,6 +1,6 @@
 """Model modules for Stage-1."""
 
 from .config import ModelConfig
-from .stage1_model import Stage1Model, load_stage0_state
+from .stage1_model import CheckpointMetadata, Stage1Model, load_stage1_checkpoint
 
-__all__ = ["ModelConfig", "Stage1Model", "load_stage0_state"]
+__all__ = ["ModelConfig", "Stage1Model", "load_stage1_checkpoint", "CheckpointMetadata"]

--- a/vertex/package/Stage_1/Stage_1/models/stage1_model.py
+++ b/vertex/package/Stage_1/Stage_1/models/stage1_model.py
@@ -1,19 +1,31 @@
-"""Stage-1 model definition and checkpoint loading."""
+"""Stage-1 model definition and checkpoint utilities."""
 
 from __future__ import annotations
 
 import io
 import json
 import os
+from dataclasses import dataclass
 from typing import Dict, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils import checkpoint as checkpoint_utils
 
+from ..utils.io import open_sharded_file
 from .blocks import ClassicBlock, LiquidBlock
 from .config import ModelConfig
-from ..utils.io import open_sharded_file
-from torch.utils import checkpoint as checkpoint_utils
+
+
+@dataclass
+class CheckpointMetadata:
+    """Metadata parsed from a Stage-1 checkpoint."""
+
+    step: int
+    metric_value: Optional[float]
+    metrics: Dict[str, float]
+    optimizer_state: Optional[dict] = None
+    scheduler_state: Optional[dict] = None
 
 
 class Stage1Model(nn.Module):
@@ -26,20 +38,45 @@ class Stage1Model(nn.Module):
         self.token_embed = nn.Embedding(config.vocab_size, self.d_model)
         self.pos_embed = nn.Parameter(torch.zeros(1, config.max_seq_len, self.d_model))
         self.dropout = nn.Dropout(config.dropout)
-        self.gradient_checkpointing = config.gradient_checkpointing
+        self.gradient_checkpointing = bool(config.gradient_checkpointing)
 
-        blocks = []
-        for _ in range(config.n_layers):
-            blocks.append(LiquidBlock(self.d_model, config.n_heads, dropout=config.dropout, layer_norm_eps=config.layer_norm_eps))
-        for _ in range(config.add_classic):
-            blocks.append(ClassicBlock(self.d_model, config.n_heads, dropout=config.dropout, layer_norm_eps=config.layer_norm_eps))
-        for _ in range(config.add_liquid):
-            blocks.append(LiquidBlock(self.d_model, config.n_heads, dropout=config.dropout, layer_norm_eps=config.layer_norm_eps))
+        blocks: list[nn.Module] = []
+        blocks.extend(
+            LiquidBlock(
+                self.d_model,
+                config.n_heads,
+                dropout=config.dropout,
+                layer_norm_eps=config.layer_norm_eps,
+            )
+            for _ in range(config.n_layers)
+        )
+        blocks.extend(
+            ClassicBlock(
+                self.d_model,
+                config.n_heads,
+                dropout=config.dropout,
+                layer_norm_eps=config.layer_norm_eps,
+            )
+            for _ in range(config.add_classic)
+        )
+        blocks.extend(
+            LiquidBlock(
+                self.d_model,
+                config.n_heads,
+                dropout=config.dropout,
+                layer_norm_eps=config.layer_norm_eps,
+            )
+            for _ in range(config.add_liquid)
+        )
         self.blocks = nn.ModuleList(blocks)
         self.norm = nn.LayerNorm(self.d_model, eps=config.layer_norm_eps)
         self.lm_head = nn.Linear(self.d_model, config.vocab_size, bias=False)
+
         self.apply(self._init_weights)
 
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
     def _init_weights(self, module: nn.Module) -> None:
         if isinstance(module, nn.Linear):
             nn.init.normal_(module.weight, mean=0.0, std=0.02)
@@ -48,88 +85,162 @@ class Stage1Model(nn.Module):
         elif isinstance(module, nn.Embedding):
             nn.init.normal_(module.weight, mean=0.0, std=0.02)
 
-    def forward(self, input_ids: torch.Tensor, attention_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         positions = self.pos_embed[:, : input_ids.size(1), :]
-        x = self.token_embed(input_ids) + positions
-        x = self.dropout(x)
-        key_padding_mask = None
-        if attention_mask is not None:
-            key_padding_mask = attention_mask == 0
+        hidden_states = self.token_embed(input_ids) + positions
+        hidden_states = self.dropout(hidden_states)
+        key_padding_mask = (attention_mask == 0) if attention_mask is not None else None
+
         for block in self.blocks:
             if self.gradient_checkpointing and self.training:
-                x = checkpoint_utils.checkpoint(lambda inp, blk=block, mask=key_padding_mask: blk(inp, key_padding_mask=mask), x)
+                hidden_states = checkpoint_utils.checkpoint(  # type: ignore[arg-type]
+                    lambda tensor, blk=block, mask=key_padding_mask: blk(
+                        tensor, key_padding_mask=mask
+                    ),
+                    hidden_states,
+                    use_reentrant=False,
+                )
             else:
-                x = block(x, key_padding_mask=key_padding_mask)
-        x = self.norm(x)
-        logits = self.lm_head(x)
+                hidden_states = block(hidden_states, key_padding_mask=key_padding_mask)
+
+        hidden_states = self.norm(hidden_states)
+        logits = self.lm_head(hidden_states)
         return logits
 
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
     @torch.no_grad()
     def generate(self, input_ids: torch.Tensor, max_new_tokens: int) -> torch.Tensor:
         self.eval()
-        with torch.no_grad():
-            seq = input_ids
-            for _ in range(max_new_tokens):
-                logits = self.forward(seq)
-                next_token = torch.argmax(logits[:, -1, :], dim=-1, keepdim=True)
-                seq = torch.cat([seq, next_token], dim=1)
-            return seq
+        generated = input_ids
+        for _ in range(max_new_tokens):
+            logits = self.forward(generated)
+            next_token = torch.argmax(logits[:, -1, :], dim=-1, keepdim=True)
+            generated = torch.cat([generated, next_token], dim=1)
+        return generated
 
-    def write_freeze_mask(self, output_dir: str) -> None:
+    def write_freeze_mask(self, output_dir: str | None) -> None:
         mask = {
             f"blocks.{idx}": isinstance(block, ClassicBlock)
             for idx, block in enumerate(self.blocks)
         }
-        target = os.path.join(output_dir, "freeze_mask.json") if output_dir else "freeze_mask.json"
-        with open_sharded_file(target, "w") as f:
-            json.dump(mask, f, indent=2, sort_keys=True)
+        target_dir = output_dir or "."
+        path = os.path.join(target_dir, "freeze_mask.json")
+        with open_sharded_file(path, "w") as handle:
+            json.dump(mask, handle, indent=2, sort_keys=True)
 
 
-def load_stage0_state(model: Stage1Model, checkpoint_path: str, device: Optional[torch.device] = None) -> Dict[str, torch.Tensor]:
-    """Load a Stage-0 checkpoint into the widened Stage-1 model."""
+# ----------------------------------------------------------------------
+# Checkpoint helpers
+# ----------------------------------------------------------------------
+def _load_checkpoint_bytes(path: str) -> bytes:
+    if path.startswith("gs://"):
+        with open_sharded_file(path, "rb") as handle:
+            return handle.read()
+    with open(path, "rb") as handle:
+        return handle.read()
 
-    if checkpoint_path.startswith("gs://"):
-        with open_sharded_file(checkpoint_path, "rb") as fh:
-            buffer = io.BytesIO(fh.read())
-        state = torch.load(buffer, map_location=device or "cpu")
-    else:
-        state = torch.load(checkpoint_path, map_location=device or "cpu")
-    if "state_dict" in state:
-        state = state["state_dict"]
-    stage1_state = model.state_dict()
-    remapped: Dict[str, torch.Tensor] = {}
-    for key, tensor in state.items():
-        if key not in stage1_state:
+
+def _infer_block_count(state_dict: Dict[str, torch.Tensor]) -> int:
+    indices = set()
+    prefix = "blocks."
+    for key in state_dict:
+        if not key.startswith(prefix):
             continue
-        target = stage1_state[key]
-        if tensor.shape == target.shape:
-            remapped[key] = tensor
-        elif tensor.ndim == 2:
-            new_tensor = tensor
-            pad_rows = target.shape[0] - tensor.shape[0]
-            pad_cols = target.shape[1] - tensor.shape[1]
-            if pad_rows > 0:
-                row_pad = torch.zeros(pad_rows, tensor.shape[1], dtype=tensor.dtype)
-                new_tensor = torch.cat([new_tensor, row_pad], dim=0)
-            if pad_cols > 0:
-                col_pad = torch.zeros(new_tensor.shape[0], pad_cols, dtype=tensor.dtype)
-                new_tensor = torch.cat([new_tensor, col_pad], dim=1)
-            remapped[key] = new_tensor[: target.shape[0], : target.shape[1]]
-        elif tensor.ndim == 1 and tensor.shape[0] != target.shape[0]:
-            pad_rows = target.shape[0] - tensor.shape[0]
-            if pad_rows <= 0:
-                remapped[key] = tensor[: target.shape[0]]
-            else:
-                pad = torch.zeros(pad_rows, dtype=tensor.dtype)
-                remapped[key] = torch.cat([tensor, pad], dim=0)
-        else:
-            remapped[key] = tensor
-    missing, unexpected = model.load_state_dict(remapped, strict=False)
-    if missing:
-        print(f"Warning: missing keys during load: {missing}")
-    if unexpected:
-        print(f"Warning: unexpected keys ignored: {unexpected}")
-    return remapped
+        remainder = key[len(prefix) :]
+        block_id, *_ = remainder.split(".")
+        if block_id.isdigit():
+            indices.add(int(block_id))
+    return len(indices)
 
 
-__all__ = ["Stage1Model", "load_stage0_state"]
+def _validate_checkpoint_shapes(
+    model: Stage1Model,
+    state_dict: Dict[str, torch.Tensor],
+) -> None:
+    expected = model.state_dict()
+
+    width_key = "token_embed.weight"
+    if width_key not in state_dict:
+        raise ValueError("Checkpoint is missing token embedding weights; incompatible with Stage-1 model")
+
+    checkpoint_width = state_dict[width_key].shape[1]
+    expected_width = expected[width_key].shape[1]
+    if checkpoint_width != expected_width:
+        raise ValueError(
+            "Checkpoint hidden width mismatch: expected "
+            f"{expected_width}, found {checkpoint_width}. Ensure the post-surgery checkpoint was produced"
+            " with the same widen_pct and head configuration."
+        )
+
+    checkpoint_blocks = _infer_block_count(state_dict)
+    expected_blocks = len(model.blocks)
+    if checkpoint_blocks != expected_blocks:
+        raise ValueError(
+            "Checkpoint depth mismatch: expected "
+            f"{expected_blocks} transformer blocks, found {checkpoint_blocks}."
+        )
+
+    mismatched: list[str] = []
+    for key, tensor in state_dict.items():
+        if key in expected and expected[key].shape != tensor.shape:
+            mismatched.append(
+                f"{key} (expected {tuple(expected[key].shape)}, got {tuple(tensor.shape)})"
+            )
+    if mismatched:
+        raise ValueError(
+            "Checkpoint parameter shape mismatch detected:\n" + "\n".join(sorted(mismatched))
+        )
+
+
+def load_stage1_checkpoint(
+    model: Stage1Model,
+    checkpoint_path: str,
+    device: torch.device | str | None = None,
+) -> CheckpointMetadata:
+    """Load a post-surgery Stage-1 checkpoint into ``model``.
+
+    The loader validates the depth/width of the checkpoint before loading it in ``strict``
+    mode. ``checkpoint_path`` may point to a local file or to a GCS URI.
+    """
+
+    raw = _load_checkpoint_bytes(checkpoint_path)
+    buffer = io.BytesIO(raw)
+    state = torch.load(buffer, map_location=device or "cpu")
+    state_dict = state.get("state_dict", state)
+    if not isinstance(state_dict, dict):
+        raise ValueError("Checkpoint format is invalid: expected mapping state_dict")
+
+    _validate_checkpoint_shapes(model, state_dict)
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if missing or unexpected:
+        raise ValueError(
+            "Checkpoint compatibility failure. Missing keys: "
+            f"{sorted(missing)}; unexpected keys: {sorted(unexpected)}"
+        )
+
+    step = int(state.get("step", 0))
+    metric_value = None
+    metrics: Dict[str, float] = {}
+    if isinstance(state.get("metrics"), dict):
+        metrics = {k: float(v) for k, v in state["metrics"].items() if isinstance(v, (int, float))}
+        metric_value = metrics.get("val_perplexity")
+
+    optimizer_state = state.get("optimizer") if isinstance(state, dict) else None
+    scheduler_state = state.get("scheduler") if isinstance(state, dict) else None
+
+    return CheckpointMetadata(
+        step=step,
+        metric_value=metric_value,
+        metrics=metrics,
+        optimizer_state=optimizer_state,
+        scheduler_state=scheduler_state,
+    )
+
+
+__all__ = ["Stage1Model", "load_stage1_checkpoint", "CheckpointMetadata"]

--- a/vertex/package/Stage_1/Stage_1/monitoring/metrics.py
+++ b/vertex/package/Stage_1/Stage_1/monitoring/metrics.py
@@ -1,45 +1,92 @@
-"""Metric aggregation helpers."""
+"""Metric aggregation helpers for evaluation and logging."""
 
 from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Optional
+
 
 @dataclass
 class MetricState:
     total_loss: float = 0.0
     total_tokens: int = 0
-    kd_kl: float = 0.0
+    kd_kl_sum: float = 0.0
+    kd_kl_count: int = 0
     math_correct: int = 0
     math_total: int = 0
     tool_calls: int = 0
     tool_total: int = 0
+    grad_norm: Optional[float] = None
+    tokens_per_sec: Optional[float] = None
+    gpu_mem_reserved: Optional[float] = None
 
 
 @dataclass
 class MetricAggregator:
+    """Aggregates per-batch metrics into concise evaluation summaries."""
+
     state: MetricState = field(default_factory=MetricState)
 
-    def update(self, loss: float, tokens: int, kd_kl: float | None = None, math_correct: int | None = None, math_total: int | None = None, tool_calls: int | None = None, tool_total: int | None = None) -> None:
+    def update(
+        self,
+        *,
+        loss: float,
+        tokens: int,
+        kd_kl: float | None = None,
+        math_correct: int | None = None,
+        math_total: int | None = None,
+        tool_calls: int | None = None,
+        tool_total: int | None = None,
+        grad_norm: float | None = None,
+        tokens_per_sec: float | None = None,
+        gpu_mem_reserved: float | None = None,
+    ) -> None:
         self.state.total_loss += loss * tokens
         self.state.total_tokens += tokens
+
         if kd_kl is not None:
-            self.state.kd_kl = kd_kl
+            self.state.kd_kl_sum += kd_kl
+            self.state.kd_kl_count += 1
+
         if math_correct is not None and math_total is not None:
             self.state.math_correct += math_correct
             self.state.math_total += math_total
+
         if tool_calls is not None and tool_total is not None:
             self.state.tool_calls += tool_calls
             self.state.tool_total += tool_total
 
+        if grad_norm is not None:
+            self.state.grad_norm = grad_norm
+        if tokens_per_sec is not None:
+            self.state.tokens_per_sec = tokens_per_sec
+        if gpu_mem_reserved is not None:
+            self.state.gpu_mem_reserved = gpu_mem_reserved
+
     def compute(self) -> Dict[str, float]:
         metrics: Dict[str, float] = {}
         if self.state.total_tokens > 0:
-            metrics["val_perplexity"] = math.exp(self.state.total_loss / self.state.total_tokens)
-        metrics["kd_kl"] = self.state.kd_kl
-        metrics["math_em"] = self.state.math_correct / max(1, self.state.math_total or 1)
-        metrics["tool_call_rate"] = self.state.tool_calls / max(1, self.state.tool_total or 1)
+            avg_loss = self.state.total_loss / self.state.total_tokens
+            metrics["val_perplexity"] = math.exp(avg_loss)
+        else:
+            metrics["val_perplexity"] = float("inf")
+
+        if self.state.kd_kl_count > 0:
+            metrics["kd_kl"] = self.state.kd_kl_sum / self.state.kd_kl_count
+        else:
+            metrics["kd_kl"] = 0.0
+
+        denom = max(1, self.state.math_total)
+        metrics["math_em"] = self.state.math_correct / denom
+
+        tool_denom = max(1, self.state.tool_total)
+        metrics["tool_call_rate"] = self.state.tool_calls / tool_denom
+
+        metrics["grad_norm"] = float(self.state.grad_norm or 0.0)
+        metrics["tokens_per_sec"] = float(self.state.tokens_per_sec or 0.0)
+        metrics["gpu_mem_reserved"] = float(self.state.gpu_mem_reserved or 0.0)
+
         return metrics
 
 

--- a/vertex/package/Stage_1/Stage_1/runbooks/arguments.txt
+++ b/vertex/package/Stage_1/Stage_1/runbooks/arguments.txt
@@ -1,4 +1,4 @@
---resume_gcs_uri=>>>PASTE_STAGE0_OR_STAGE1_START_CKPT<<<
+--resume_gcs_uri=>>>PASTE_POST_SURGERY_CKPT_GCS_URI<<<
 --output_gcs_uri=gs://liquid-llm-bucket-2/stage1/checkpoints/vertex_runs/$(date +%Y%m%d-%H%M%S)
 --teacher=llama-3.1-8b
 --seq_len=1024

--- a/vertex/package/Stage_1/Stage_1/trainer.py
+++ b/vertex/package/Stage_1/Stage_1/trainer.py
@@ -15,9 +15,9 @@ from torch.optim import AdamW
 from .checkpoints import BestCheckpointSaver
 from .distillation import DistillationConfig, DistillationLoss, TeacherConfig, TeacherModel
 from .monitoring import HealthMonitor, MetricAggregator, StructuredLogger
-from .models import ModelConfig, Stage1Model, load_stage0_state
+from .models import ModelConfig, Stage1Model, load_stage1_checkpoint
 from .models.blocks import ClassicBlock
-from .utils import WarmupCosineScheduler, config_to_dict
+from .utils import WarmupCosineScheduler, config_to_dict, ensure_output_path
 from .data import DataMixer, load_manifest
 from .tools import ToolTraceInjector
 
@@ -29,9 +29,14 @@ class TrainerState:
 
 class Stage1Trainer:
     def __init__(self, config, device: Optional[torch.device] = None):
+        if not config.resume_gcs_uri:
+            raise ValueError(
+                "Stage-1 training requires --resume_gcs_uri to point to a post-surgery checkpoint."
+            )
+
         self.config = config
-        self.device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        self.dtype = torch.bfloat16 if config.precision == "bfloat16" and torch.cuda.is_available() else torch.float32
+        self.device = device or torch.device(config.device if torch.cuda.is_available() else "cpu")
+        self.dtype = torch.bfloat16 if (config.precision == "bfloat16" and self.device.type == "cuda") else torch.float32
         self.model_config = ModelConfig(
             max_seq_len=config.seq_len,
             widen_pct=config.net2net_width_pct,
@@ -42,35 +47,76 @@ class Stage1Trainer:
         self.model = Stage1Model(self.model_config).to(self.device)
         if self.dtype == torch.bfloat16:
             self.model = self.model.to(dtype=torch.bfloat16)
-        self.optimizer = AdamW(self.model.parameters(), lr=config.lr, betas=tuple(float(x) for x in config.betas.split(",")), weight_decay=config.weight_decay)
-        self.scheduler = WarmupCosineScheduler(self.optimizer, warmup_steps=config.warmup_steps, total_steps=config.max_steps)
-        self.state = TrainerState()
-        self.output_path = config.output_gcs_uri or "./stage1_output"
-        self.logger = StructuredLogger(self.output_path, run_id=config.run_id, git_sha=self._git_sha())
-        self.health = HealthMonitor(self.logger, max_grad_norm=config.max_grad_norm)
-        self.distillation = DistillationLoss(
-            DistillationConfig(
-                temperature=config.kd_temperature,
-                alpha_start=config.kd_alpha_start,
-                alpha_end=config.kd_alpha_end,
-                anneal_pct=config.kd_anneal_pct,
-                keep_old_logit_l2=config.keep_old_logit_l2,
-                keep_old_logit_l2_fade_step=config.keep_old_logit_l2_fade_step,
-                keep_old_logit_l2_enable=config.keep_old_logit_l2_enable,
-            ),
+
+        betas = tuple(float(x) for x in str(config.betas).split(","))
+        self.optimizer = AdamW(self.model.parameters(), lr=config.lr, betas=betas, weight_decay=config.weight_decay)
+        self.scheduler = WarmupCosineScheduler(
+            self.optimizer,
+            warmup_steps=config.warmup_steps,
             total_steps=config.max_steps,
         )
+        self.state = TrainerState()
+
+        self.output_path = config.output_gcs_uri or "./stage1_output"
+        if self.output_path and not self.output_path.startswith("gs://"):
+            ensure_output_path(self.output_path)
+
+        self.logger = StructuredLogger(self.output_path, run_id=config.run_id, git_sha=self._git_sha())
+        self.health = HealthMonitor(self.logger, max_grad_norm=config.max_grad_norm)
+
+        if getattr(config, "do_surgery", False):
+            self.logger.health("warning", "surgery_disabled", detail="Stage-1 skips surgery by design")
+            config.do_surgery = False
+
+        if config.best_metric != "val_perplexity" or config.best_metric_mode != "min":
+            self.logger.info(
+                "checkpoint_metric_override",
+                best_metric="val_perplexity",
+                mode="min",
+            )
+            config.best_metric = "val_perplexity"
+            config.best_metric_mode = "min"
+
+        distil_cfg = DistillationConfig(
+            temperature=config.kd_temperature,
+            alpha_start=config.kd_alpha_start,
+            alpha_end=config.kd_alpha_end,
+            anneal_pct=config.kd_anneal_pct,
+            keep_old_logit_l2=config.keep_old_logit_l2,
+            keep_old_logit_l2_fade_step=config.keep_old_logit_l2_fade_step,
+            keep_old_logit_l2_enable=config.keep_old_logit_l2_enable,
+        )
+        self.distillation = DistillationLoss(distil_cfg, total_steps=config.max_steps)
+
         self.teacher: Optional[TeacherModel] = None
-        if config.teacher and config.teacher.lower() != "none":
+        teacher_id = self._resolve_teacher_id()
+        teacher_endpoint = getattr(config, "teacher_endpoint", None)
+        if (teacher_id or teacher_endpoint) and str(config.teacher).lower() != "none":
+            teacher_cfg = TeacherConfig(
+                model_id=teacher_id,
+                endpoint=teacher_endpoint,
+                hf_secret_name=config.hf_secret_name,
+                hf_cache_dir=getattr(config, "hf_cache_dir", None),
+                device=config.device,
+                max_batch_size=getattr(config, "teacher_max_batch_size", 0),
+            )
             try:
-                self.teacher = TeacherModel(TeacherConfig(model_name=config.teacher, hf_secret_name=config.hf_secret_name))
+                self.teacher = TeacherModel(teacher_cfg)
             except Exception as exc:  # pragma: no cover - external dependency
                 self.logger.health("warning", "teacher_unavailable", error=str(exc))
                 self.teacher = None
+
         self.old_logit_reference = None
-        if config.use_old_logit_reference:
+        if getattr(config, "use_old_logit_reference", None):
             self.old_logit_reference = torch.load(config.use_old_logit_reference, map_location="cpu")
-        self.saver = BestCheckpointSaver(self.output_path, metric=config.best_metric, mode=config.best_metric_mode, logger=self.logger)
+
+        self.saver = BestCheckpointSaver(
+            self.output_path,
+            metric=config.best_metric,
+            mode=config.best_metric_mode,
+            logger=self.logger,
+        )
+
         self.mixer = None
         if config.dataset_cfg and os.path.exists(config.dataset_cfg):
             manifest = load_manifest(config.dataset_cfg)
@@ -80,29 +126,42 @@ class Stage1Trainer:
             self.logger.info("dataset_manifest_remote", path=config.dataset_cfg)
         self.sample_iterator = self.mixer.iter_samples() if self.mixer else None
         self._logged_sources: set[str] = set()
-        self.tool_injector = ToolTraceInjector(
-            calculator_enabled=config.calculator_enabled,
-            scratchpad_enabled=config.scratchpad_enabled,
-            max_calls=max(1, int(config.seq_len * config.tool_use_ratio))
-        ) if (config.calculator_enabled or config.scratchpad_enabled) else None
+
+        self.tool_injector = (
+            ToolTraceInjector(
+                calculator_enabled=config.calculator_enabled,
+                scratchpad_enabled=config.scratchpad_enabled,
+                max_calls=max(1, int(config.seq_len * config.tool_use_ratio)),
+            )
+            if (config.calculator_enabled or config.scratchpad_enabled)
+            else None
+        )
+
         self.last_tokens_per_sec = 0.0
         self.last_gpu_mem = 0.0
         self.last_grad_norm = 0.0
-        self._log_startup()
-        if config.resume_gcs_uri:
-            try:
-                load_stage0_state(self.model, config.resume_gcs_uri, device=self.device)
-                self.logger.info("resume_loaded", path=config.resume_gcs_uri)
-            except FileNotFoundError:
-                self.logger.info("resume_missing", path=config.resume_gcs_uri)
-            except Exception as exc:  # pragma: no cover
-                self.logger.health("warning", "resume_failed", error=str(exc))
+        self._last_log_time = time.time()
 
+        self._log_startup()
+        self._resume_from_checkpoint()
+
+    # ------------------------------------------------------------------
     def _git_sha(self) -> Optional[str]:
         try:
             return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=os.getcwd()).decode().strip()
-        except Exception:
+        except Exception:  # pragma: no cover - git not available
             return None
+
+    def _resolve_teacher_id(self) -> str:
+        requested = getattr(self.config, "teacher_id", None)
+        if requested and str(requested).lower() != "none":
+            return requested
+        alias = str(getattr(self.config, "teacher", "")).lower()
+        known = {
+            "llama-3.1-8b": "meta-llama/Meta-Llama-3.1-8B",
+            "llama-3.1-8b-instruct": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        }
+        return known.get(alias, "meta-llama/Meta-Llama-3.1-8B")
 
     def _log_startup(self) -> None:
         mem = torch.cuda.get_device_properties(0).total_memory if torch.cuda.is_available() else 0
@@ -117,6 +176,37 @@ class Stage1Trainer:
             use_flash_attn=self.config.use_flash_attn,
         )
 
+    def _resume_from_checkpoint(self) -> None:
+        try:
+            metadata = load_stage1_checkpoint(self.model, self.config.resume_gcs_uri, device=self.device)
+        except Exception as exc:
+            self.logger.health("error", "resume_failed", detail=str(exc))
+            raise
+
+        self.state.step = metadata.step
+        if metadata.optimizer_state:
+            try:
+                self.optimizer.load_state_dict(metadata.optimizer_state)
+            except Exception as exc:  # pragma: no cover - optimizer mismatch
+                self.logger.health("warning", "optimizer_state_mismatch", error=str(exc))
+        scheduler_state = metadata.scheduler_state or {"step": metadata.step}
+        try:
+            self.scheduler.load_state_dict(scheduler_state)
+        except Exception as exc:  # pragma: no cover
+            self.logger.health("warning", "scheduler_state_mismatch", error=str(exc))
+        else:
+            lrs = list(self.scheduler.get_lr())
+            for lr, group in zip(lrs, self.optimizer.param_groups):
+                group["lr"] = lr
+
+        self.logger.info(
+            "resume_loaded",
+            path=self.config.resume_gcs_uri,
+            step=metadata.step,
+            val_perplexity=metadata.metric_value,
+        )
+
+    # ------------------------------------------------------------------
     def _fake_batch(self, batch_size: int) -> Dict[str, torch.Tensor]:
         seq_len = self.config.seq_len
         vocab = self.model_config.vocab_size
@@ -148,10 +238,11 @@ class Stage1Trainer:
             attn = batch["attention_mask"].to(self.device)
             logits = self.model(inputs, attention_mask=attn)
             loss = F.cross_entropy(logits.view(-1, logits.size(-1)), batch["labels"].view(-1), ignore_index=-100)
-            teacher_logits = logits
+            teacher_logits = logits.detach()
             if self.teacher is not None:
                 teacher_logits = self.teacher.logits(inputs, attention_mask=attn)
-            metrics = self.distillation(0, logits, teacher_logits, batch["labels"])  # teacher placeholder
+            metrics = self.distillation(self.state.step, logits, teacher_logits, batch["labels"])
+
             math_total = 0
             math_correct = 0
             tool_calls = 0
@@ -163,37 +254,46 @@ class Stage1Trainer:
                 tool_calls = 1
                 math_total = 1
                 math_correct = 1 if any("RESULT:4" in t for t in trace) else 0
+
             aggregator.update(
-                loss.item(),
-                batch["labels"].numel(),
-                kd_kl=metrics["kd_loss"].item(),
+                loss=float(loss.item()),
+                tokens=int(attn.sum().item()),
+                kd_kl=float(metrics["kd_loss"].item()),
                 math_correct=math_correct,
                 math_total=math_total,
                 tool_calls=tool_calls,
                 tool_total=tool_total,
+                grad_norm=self.last_grad_norm,
+                tokens_per_sec=self.last_tokens_per_sec,
+                gpu_mem_reserved=self.last_gpu_mem,
             )
         self.model.train()
         return aggregator.compute()
 
+    # ------------------------------------------------------------------
     def train(self) -> None:
-        grad_accum = self.config.gradient_accumulation_steps
+        grad_accum = max(1, self.config.gradient_accumulation_steps)
         self.model.train()
-        start = time.time()
-        for step in range(1, self.config.max_steps + 1):
+        self.optimizer.zero_grad(set_to_none=True)
+
+        start_step = self.state.step
+        for step in range(start_step + 1, self.config.max_steps + 1):
             self.state.step = step
             batch = self._fake_batch(self.config.batch_size)
+
             try:
                 with torch.cuda.amp.autocast(enabled=self.dtype == torch.bfloat16):
                     logits = self.model(batch["input_ids"], attention_mask=batch["attention_mask"])
                     teacher_logits = logits.detach()
                     if self.teacher is not None:
-                        teacher_logits = self.teacher.logits(batch["input_ids"], attention_mask=batch["attention_mask"])
-                    old_logits = None
-                    if self.old_logit_reference is not None:
-                        old_logits = self.old_logit_reference
+                        teacher_logits = self.teacher.logits(
+                            batch["input_ids"], attention_mask=batch["attention_mask"]
+                        )
+                    old_logits = self.old_logit_reference
                     distil = self.distillation(step, logits, teacher_logits, batch["labels"], old_logits=old_logits)
-                    loss = distil["total_loss"] / grad_accum
-                self.health.check_loss(loss)
+                    total_loss = distil["total_loss"]
+                    loss = total_loss / grad_accum
+                self.health.check_loss(loss.detach())
                 loss.backward()
             except RuntimeError as err:
                 if "out of memory" in str(err).lower():
@@ -202,6 +302,7 @@ class Stage1Trainer:
                         torch.cuda.empty_cache()
                     continue
                 raise
+
             if step % grad_accum == 0:
                 grad_norm = torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.config.max_grad_norm)
                 self.last_grad_norm = float(grad_norm)
@@ -209,25 +310,39 @@ class Stage1Trainer:
                 self.optimizer.step()
                 self.scheduler.step()
                 self.optimizer.zero_grad(set_to_none=True)
+
             if step % self.config.log_every == 0:
-                elapsed = time.time() - start
+                now = time.time()
+                elapsed = now - self._last_log_time
                 tokens = self.config.batch_size * self.config.seq_len * self.config.log_every
-                tps, mem = self.health.report_throughput(tokens, elapsed, step)
-                self.last_tokens_per_sec = tps
+                tokens_per_sec, mem = self.health.report_throughput(tokens, elapsed, step)
+                self.last_tokens_per_sec = tokens_per_sec
                 self.last_gpu_mem = mem
-                start = time.time()
+                self.logger.info(
+                    "train_progress",
+                    step=step,
+                    loss=float(total_loss.detach().item()),
+                    lr=float(self.optimizer.param_groups[0]["lr"]),
+                    tokens_per_sec=tokens_per_sec,
+                )
+                self._last_log_time = now
+
             if step % self.config.eval_every == 0:
                 metrics = self._eval()
-                metrics.update({
-                    "grad_norm": self.last_grad_norm,
-                    "tokens_per_sec": self.last_tokens_per_sec,
-                    "gpu_mem_reserved": self.last_gpu_mem,
-                })
                 self.logger.metric(step, metrics)
                 if self.config.use_checkpoint_saver:
-                    freeze_mask = {f"blocks.{i}": isinstance(block, ClassicBlock) for i, block in enumerate(self.model.blocks)}
-                    self.saver.save(self.model, self.optimizer, self.scheduler.state_dict(), step, metrics, freeze_mask=freeze_mask, config=config_to_dict(self.config))
-        self.model.write_freeze_mask(self.output_path)
+                    freeze_mask = {
+                        f"blocks.{i}": isinstance(block, ClassicBlock) for i, block in enumerate(self.model.blocks)
+                    }
+                    self.saver.save(
+                        self.model,
+                        self.optimizer,
+                        self.scheduler.state_dict(),
+                        step,
+                        metrics,
+                        freeze_mask=freeze_mask,
+                        config=config_to_dict(self.config),
+                    )
 
 
 __all__ = ["Stage1Trainer"]

--- a/vertex/package/Stage_1/Stage_1/utils/__init__.py
+++ b/vertex/package/Stage_1/Stage_1/utils/__init__.py
@@ -10,7 +10,7 @@ from .config_utils import (
 )
 from .schedule import WarmupCosineScheduler
 from .io import open_sharded_file, write_jsonl
-from .secrets import get_secret
+from .secrets import get_secret, get_hf_token
 from .ddp import setup_ddp, cleanup_ddp
 
 __all__ = [
@@ -24,6 +24,7 @@ __all__ = [
     "open_sharded_file",
     "write_jsonl",
     "get_secret",
+    "get_hf_token",
     "setup_ddp",
     "cleanup_ddp",
 ]

--- a/vertex/package/Stage_1/Stage_1/utils/config_utils.py
+++ b/vertex/package/Stage_1/Stage_1/utils/config_utils.py
@@ -22,6 +22,9 @@ class Stage1Config:
     resume_gcs_uri: Optional[str] = None
     output_gcs_uri: Optional[str] = None
     teacher: str = "llama-3.1-8b"
+    teacher_id: str = "meta-llama/Meta-Llama-3.1-8B"
+    teacher_endpoint: Optional[str] = None
+    teacher_max_batch_size: int = 0
     seq_len: int = 1024
     net2net_width_pct: float = 10.0
     add_blocks_classic: int = 2
@@ -134,6 +137,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--resume_gcs_uri", type=str, required=False)
     parser.add_argument("--output_gcs_uri", type=str, required=False)
     parser.add_argument("--teacher", type=str, default="llama-3.1-8b")
+    parser.add_argument("--teacher_id", type=str, default="meta-llama/Meta-Llama-3.1-8B")
+    parser.add_argument("--teacher_endpoint", type=str, default=None)
+    parser.add_argument("--teacher_max_batch_size", type=int, default=0)
     parser.add_argument("--seq_len", type=int, default=1024)
     parser.add_argument("--net2net_width_pct", type=float, default=10.0)
     parser.add_argument("--add_blocks_classic", type=int, default=2)

--- a/vertex/package/Stage_1/Stage_1/utils/secrets.py
+++ b/vertex/package/Stage_1/Stage_1/utils/secrets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Optional
 
 try:
@@ -37,4 +38,21 @@ def get_secret(secret_name: str, project_id: Optional[str] = None) -> Optional[s
     return payload
 
 
-__all__ = ["get_secret"]
+def get_hf_token(secret_name: Optional[str], project_id: Optional[str] = None) -> Optional[str]:
+    """Resolve a Hugging Face token from env vars or Secret Manager."""
+
+    for env_var in ("HF_TOKEN", "HF_API_TOKEN", "HUGGINGFACEHUB_API_TOKEN"):
+        value = os.getenv(env_var)
+        if value:
+            return value.strip()
+
+    if not secret_name:
+        return None
+
+    token = get_secret(secret_name, project_id=project_id)
+    if token:
+        return token.strip()
+    return None
+
+
+__all__ = ["get_secret", "get_hf_token"]

--- a/vertex/package/Stage_1/pyproject.toml
+++ b/vertex/package/Stage_1/pyproject.toml
@@ -7,7 +7,21 @@ name = "Stage-1"
 version = "0.1.0"
 description = "Stage-1 Vertex AI training package for Liquid LLM"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "torch==2.3.1",
+    "einops==0.8.0",
+    "numpy==1.26.4",
+    "tqdm==4.66.4",
+    "pyyaml==6.0.2",
+    "transformers>=4.42.0",
+    "accelerate>=0.30.0",
+    "sentencepiece>=0.2.0",
+    "datasets>=2.20.0",
+    "huggingface_hub>=0.23.0",
+    "tokenizers>=0.15.2",
+    "google-cloud-storage>=2.17.0",
+    "google-cloud-secret-manager>=2.20.0",
+]
 
 [tool.setuptools.packages.find]
 where = ["Stage_1"]


### PR DESCRIPTION
## Summary
- add pinned torch, hf, and google client dependencies for the Stage-1 package
- rebuild the Stage-1 model, trainer, CLI, and config flow to resume from post-surgery checkpoints, emit concise metrics, and save best-only artifacts
- extend the teacher wrapper to support Hugging Face or HTTP inference with secret-managed tokens and refresh the runbook placeholder

## Testing
- python -m compileall vertex/package/Stage_1/Stage_1

------
https://chatgpt.com/codex/tasks/task_e_68e85211eab88321b2b76740a1b78a47