### PR TITLE
Add Vertex entrypoint and improve Stage 1 packaging

### DIFF
--- a/vertex/package/Stage_1/Stage_1/cli.py
+++ b/vertex/package/Stage_1/Stage_1/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import uuid
 
 from .trainer import Stage1Trainer
@@ -18,7 +19,10 @@ def main(argv: list[str] | None = None) -> None:
     if not config.resume_gcs_uri:
         raise SystemExit("Stage-1 requires --resume_gcs_uri=gs://.../stage1_surgery_*.pt")
     if "surgery" not in config.resume_gcs_uri:
-        raise SystemExit("--resume_gcs_uri must reference a post-surgery checkpoint (stage1_surgery_*.pt)")
+        print(
+            "[stage1-cli] WARNING: --resume_gcs_uri does not look like a post-surgery checkpoint.",
+            file=sys.stderr,
+        )
     if config.output_gcs_uri and not config.output_gcs_uri.startswith("gs://"):
         ensure_output_path(config.output_gcs_uri)
     trainer = Stage1Trainer(config)

--- a/vertex/package/Stage_1/Stage_1/distillation/teacher_llama31_8b.py
+++ b/vertex/package/Stage_1/Stage_1/distillation/teacher_llama31_8b.py
@@ -56,7 +56,14 @@ class TeacherModel:
         if AutoModelForCausalLM is None or AutoTokenizer is None:
             raise ImportError("transformers package is required for local teacher inference")
 
-        token = config.hf_token or get_hf_token(config.hf_secret_name)
+        token = config.hf_token
+        if token is None and config.hf_secret_name:
+            try:
+                token = get_hf_token(config.hf_secret_name)
+            except ValueError as exc:  # pragma: no cover - requires misconfiguration
+                LOGGER.warning("Unable to resolve HF token without project id", exc_info=exc)
+            except Exception as exc:  # pragma: no cover - secret manager failures
+                LOGGER.warning("Failed to resolve HF token from secret", exc_info=exc)
         auth_kwargs = {}
         if token:
             auth_kwargs["use_auth_token"] = token

--- a/vertex/package/Stage_1/pyproject.toml
+++ b/vertex/package/Stage_1/pyproject.toml
@@ -21,11 +21,12 @@ dependencies = [
     "tokenizers>=0.15.2",
     "google-cloud-storage>=2.17.0",
     "google-cloud-secret-manager>=2.20.0",
+    "python-json-logger>=3.2.1",
 ]
 
 [tool.setuptools.packages.find]
 where = ["Stage_1"]
-include = ["Stage_1*"]
+include = ["Stage_1*", "trainer*"]
 
 [project.scripts]
 stage1-train = "Stage_1.cli:main"

--- a/vertex/package/Stage_1/trainer/__init__.py
+++ b/vertex/package/Stage_1/trainer/__init__.py
@@ -1,0 +1,5 @@
+"""Vertex AI compatibility layer for the Stage-1 training package."""
+
+from .entrypoint import main
+
+__all__ = ["main"]

--- a/vertex/package/Stage_1/trainer/entrypoint.py
+++ b/vertex/package/Stage_1/trainer/entrypoint.py
@@ -1,0 +1,196 @@
+"""Vertex AI entrypoint that adapts Stage-1 configuration to Vertex arguments."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+import uuid
+from typing import List, Sequence
+
+from Stage_1.cli import main as stage1_main
+from Stage_1.utils import get_hf_token
+
+_TOKEN_ENV_VARS = ("HF_TOKEN", "HF_API_TOKEN", "HUGGINGFACEHUB_API_TOKEN")
+
+
+def _parse_args(argv: Sequence[str] | None) -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(
+        description="Stage-1 Vertex AI adapter",
+        add_help=True,
+    )
+    parser.add_argument("--resume_gcs_uri", type=str, default=None)
+    parser.add_argument("--output_gcs_uri", type=str, default=None)
+    parser.add_argument("--teacher_name", type=str, default=None)
+    parser.add_argument("--teacher_endpoint", type=str, default=None)
+    parser.add_argument("--teacher_max_batch_size", type=int, default=None)
+    parser.add_argument("--dataset_name", type=str, default=None)
+    parser.add_argument("--dataset_config", type=str, default=None)
+    parser.add_argument("--dataset_cfg", type=str, default=None)
+    parser.add_argument("--block_size", type=int, default=None)
+    parser.add_argument("--train_steps", type=int, default=None)
+    parser.add_argument("--batch_size", type=int, default=None)
+    parser.add_argument("--eval_every", type=int, default=None)
+    parser.add_argument("--save_every", type=int, default=None)
+    parser.add_argument("--lr", type=float, default=None)
+    parser.add_argument("--weight_decay", type=float, default=None)
+    parser.add_argument("--betas", type=str, default=None)
+    parser.add_argument("--warmup_steps", type=int, default=None)
+    parser.add_argument("--throughput_tokens", type=int, default=None)
+    parser.add_argument("--dtype", type=str, default=None)
+    parser.add_argument("--device", type=str, default=None)
+    parser.add_argument("--hf_secret_name", type=str, default=None)
+    parser.add_argument("--hf_secret_project", type=str, default=None)
+    parser.add_argument("--hf_token_value", type=str, default=None)
+    parser.add_argument("--hf_cache_dir", type=str, default=None)
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--log_every", type=int, default=None)
+    parser.add_argument("--num_workers", type=int, default=None)
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=None)
+    parser.add_argument("--max_grad_norm", type=float, default=None)
+    known, extras = parser.parse_known_args(argv)
+    return known, extras
+
+
+def _append_flag(args: List[str], name: str, value: object | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool):
+        literal = "true" if value else "false"
+    else:
+        literal = str(value)
+    args.append(f"--{name}={literal}")
+
+
+def _teacher_alias(model_id: str | None) -> str | None:
+    if not model_id:
+        return None
+    lowered = model_id.lower()
+    if "meta-llama-3.1-8b-instruct" in lowered:
+        return "llama-3.1-8b-instruct"
+    if "meta-llama-3.1-8b" in lowered:
+        return "llama-3.1-8b"
+    return None
+
+
+def _resolve_output_uri(cli_output: str | None) -> str | None:
+    if cli_output:
+        return cli_output
+    for env_key in ("AIP_CHECKPOINT_DIR", "AIP_MODEL_DIR", "AIP_OUTPUT_DIR"):
+        value = os.getenv(env_key)
+        if value:
+            return value
+    return None
+
+
+def _resolve_project_hint(cli_value: str | None) -> str | None:
+    if cli_value:
+        return cli_value
+    for env_key in (
+        "AIP_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT",
+        "PROJECT_ID",
+        "CLOUD_ML_PROJECT_ID",
+        "GCLOUD_PROJECT",
+    ):
+        value = os.getenv(env_key)
+        if value:
+            return value
+    return None
+
+
+def _ensure_hf_token(secret_name: str | None, explicit: str | None, project_hint: str | None) -> None:
+    token = explicit
+    if token is None and secret_name:
+        try:
+            token = get_hf_token(secret_name, project_id=project_hint)
+        except ValueError as exc:
+            print(
+                f"[trainer.entrypoint] WARNING: unable to resolve secret '{secret_name}': {exc}",
+                file=sys.stderr,
+            )
+        except Exception as exc:  # pragma: no cover - networking errors
+            print(
+                f"[trainer.entrypoint] WARNING: failed to fetch secret '{secret_name}': {exc}",
+                file=sys.stderr,
+            )
+    if not token:
+        return
+    for env_key in _TOKEN_ENV_VARS:
+        os.environ.setdefault(env_key, token)
+
+
+def _maybe_warn_unused(label: str, value: object | None) -> None:
+    if value is None:
+        return
+    print(f"[trainer.entrypoint] NOTE: ignoring argument --{label}", file=sys.stderr)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    known, extras = _parse_args(argv)
+    stage1_args: list[str] = []
+
+    _append_flag(stage1_args, "resume_gcs_uri", known.resume_gcs_uri)
+    output_uri = _resolve_output_uri(known.output_gcs_uri)
+    _append_flag(stage1_args, "output_gcs_uri", output_uri)
+    _append_flag(stage1_args, "batch_size", known.batch_size)
+    _append_flag(stage1_args, "eval_every", known.eval_every)
+    _append_flag(stage1_args, "save_every", known.save_every)
+    _append_flag(stage1_args, "lr", known.lr)
+    _append_flag(stage1_args, "weight_decay", known.weight_decay)
+    _append_flag(stage1_args, "betas", known.betas)
+    _append_flag(stage1_args, "warmup_steps", known.warmup_steps)
+    _append_flag(stage1_args, "precision", known.dtype)
+    _append_flag(stage1_args, "device", known.device)
+    _append_flag(stage1_args, "hf_secret_name", known.hf_secret_name)
+    _append_flag(stage1_args, "hf_cache_dir", known.hf_cache_dir)
+    _append_flag(stage1_args, "seed", known.seed)
+    _append_flag(stage1_args, "log_every", known.log_every)
+    _append_flag(stage1_args, "num_workers", known.num_workers)
+    _append_flag(stage1_args, "gradient_accumulation_steps", known.gradient_accumulation_steps)
+    _append_flag(stage1_args, "max_grad_norm", known.max_grad_norm)
+
+    if known.block_size is not None:
+        _append_flag(stage1_args, "seq_len", known.block_size)
+    if known.train_steps is not None:
+        _append_flag(stage1_args, "max_steps", known.train_steps)
+    if known.dataset_cfg is not None:
+        _append_flag(stage1_args, "dataset_cfg", known.dataset_cfg)
+
+    if known.teacher_name:
+        alias = _teacher_alias(known.teacher_name)
+        if alias:
+            _append_flag(stage1_args, "teacher", alias)
+        _append_flag(stage1_args, "teacher_id", known.teacher_name)
+    _append_flag(stage1_args, "teacher_endpoint", known.teacher_endpoint)
+    _append_flag(stage1_args, "teacher_max_batch_size", known.teacher_max_batch_size)
+
+    run_id = known.run_id or os.getenv("AIP_TRAINING_JOB_ID") or os.getenv("AIP_JOB_ID")
+    if not run_id:
+        run_id = os.getenv("AIP_TRIAL_ID") or os.getenv("CLOUD_ML_JOB_ID")
+    if not run_id:
+        run_id = str(uuid.uuid4())
+    _append_flag(stage1_args, "run_id", run_id)
+
+    if known.throughput_tokens is not None:
+        _maybe_warn_unused("throughput_tokens", known.throughput_tokens)
+    if known.dataset_name:
+        _maybe_warn_unused("dataset_name", known.dataset_name)
+    if known.dataset_config:
+        _maybe_warn_unused("dataset_config", known.dataset_config)
+
+    project_hint = _resolve_project_hint(known.hf_secret_project)
+    _ensure_hf_token(known.hf_secret_name, known.hf_token_value, project_hint)
+
+    stage1_args.extend(extras)
+
+    cmd = " ".join(shlex.quote(arg) for arg in stage1_args)
+    print(f"[trainer.entrypoint] Launching Stage-1 CLI with arguments: {cmd}")
+    stage1_main(stage1_args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add a trainer.entrypoint module so Vertex jobs can invoke the Stage-1 package and map Vertex-style flags to the Stage-1 CLI
- resolve Hugging Face token handling by fetching secrets with project hints, seeding env vars, and tolerating missing project IDs
- relax the resume checkpoint guard and declare python-json-logger plus the new trainer package in the build metadata

## Testing
- python -m compileall vertex/package/Stage_1

------
https://chatgpt.com/codex/tasks/task_e_68e8b05204c8832196d6cb7e4755941e