### PR TITLE
Fix Stage-1 package discovery for Vertex jobs

### DIFF
--- a/vertex/package/Stage_1/pyproject.toml
+++ b/vertex/package/Stage_1/pyproject.toml
@@ -24,9 +24,20 @@ dependencies = [
     "python-json-logger>=3.2.1",
 ]
 
-[tool.setuptools.packages.find]
-where = ["Stage_1"]
-include = ["Stage_1*", "trainer*"]
+[tool.setuptools]
+package-dir = {"" = "Stage_1"}
+packages = {find = {where = ["."], include = ["Stage_1*", "trainer*"]}}
+include-package-data = true
+
+[tool.setuptools.package-data]
+"Stage_1" = [
+    "configs/*.yaml",
+    "configs/*.jsonl",
+    "runbooks/*.txt",
+    "monitoring/*.yaml",
+    "monitoring/*.json",
+    "data/**/*.json",
+]
 
 [project.scripts]
 stage1-train = "Stage_1.cli:main"


### PR DESCRIPTION
## Summary
- configure setuptools to package the Stage-1 and trainer modules from the project directory
- include configuration and monitoring assets in the built distribution so Vertex jobs can load them

## Testing
- not run (packaging change only)


------
https://chatgpt.com/codex/tasks/task_e_68e9b34c6d508321b1440e75b52df6b2