### PR TITLE
Inline trainer shim into Stage_1 package

### DIFF
--- a/vertex/package/Stage_1/Stage_1/__init__.py
+++ b/vertex/package/Stage_1/Stage_1/__init__.py
@@ -1,5 +1,36 @@
 """Stage-1 Vertex AI training package for Liquid LLM."""
 
-from . import cli as _cli  # noqa: F401  (re-export for entry point convenience)
+from __future__ import annotations
+
+import sys
+import types
+from importlib import import_module
+
+from . import cli as _cli  # noqa: F401 (re-export for entry point convenience)
 
 __all__ = ["_cli"]
+
+
+def _install_trainer_compatibility() -> None:
+    """Expose the historic ``trainer`` module path for Vertex AI jobs."""
+    if "trainer.entrypoint" in sys.modules:
+        return
+
+    entrypoint_module = import_module(".vertex.entrypoint", __name__)
+
+    shim = types.ModuleType("trainer")
+    shim.__path__ = []  # type: ignore[attr-defined]
+    shim.entrypoint = entrypoint_module
+
+    main = getattr(entrypoint_module, "main", None)
+    if main is not None:
+        shim.main = main
+        shim.__all__ = ["entrypoint", "main"]
+    else:  # pragma: no cover - defensive fallback
+        shim.__all__ = ["entrypoint"]
+
+    sys.modules["trainer"] = shim
+    sys.modules["trainer.entrypoint"] = entrypoint_module
+
+
+_install_trainer_compatibility()

--- a/vertex/package/Stage_1/Stage_1/vertex/__init__.py
+++ b/vertex/package/Stage_1/Stage_1/vertex/__init__.py
@@ -1,0 +1,3 @@
+"""Vertex AI integration helpers for the Stage-1 training package."""
+
+__all__: list[str] = []

--- a/vertex/package/Stage_1/Stage_1/vertex/entrypoint.py
+++ b/vertex/package/Stage_1/Stage_1/vertex/entrypoint.py
@@ -12,6 +12,8 @@ from typing import List, Sequence
 from Stage_1.cli import main as stage1_main
 from Stage_1.utils import get_hf_token
 
+_LOG_PREFIX = "[Stage_1.vertex.entrypoint]"
+
 _TOKEN_ENV_VARS = ("HF_TOKEN", "HF_API_TOKEN", "HUGGINGFACEHUB_API_TOKEN")
 
 
@@ -108,12 +110,12 @@ def _ensure_hf_token(secret_name: str | None, explicit: str | None, project_hint
             token = get_hf_token(secret_name, project_id=project_hint)
         except ValueError as exc:
             print(
-                f"[trainer.entrypoint] WARNING: unable to resolve secret '{secret_name}': {exc}",
+                f"{_LOG_PREFIX} WARNING: unable to resolve secret '{secret_name}': {exc}",
                 file=sys.stderr,
             )
         except Exception as exc:  # pragma: no cover - networking errors
             print(
-                f"[trainer.entrypoint] WARNING: failed to fetch secret '{secret_name}': {exc}",
+                f"{_LOG_PREFIX} WARNING: failed to fetch secret '{secret_name}': {exc}",
                 file=sys.stderr,
             )
     if not token:
@@ -125,7 +127,7 @@ def _ensure_hf_token(secret_name: str | None, explicit: str | None, project_hint
 def _maybe_warn_unused(label: str, value: object | None) -> None:
     if value is None:
         return
-    print(f"[trainer.entrypoint] NOTE: ignoring argument --{label}", file=sys.stderr)
+    print(f"{_LOG_PREFIX} NOTE: ignoring argument --{label}", file=sys.stderr)
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -188,7 +190,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     stage1_args.extend(extras)
 
     cmd = " ".join(shlex.quote(arg) for arg in stage1_args)
-    print(f"[trainer.entrypoint] Launching Stage-1 CLI with arguments: {cmd}")
+    print(f"{_LOG_PREFIX} Launching Stage-1 CLI with arguments: {cmd}")
     stage1_main(stage1_args)
 
 

--- a/vertex/package/Stage_1/pyproject.toml
+++ b/vertex/package/Stage_1/pyproject.toml
@@ -26,7 +26,10 @@ dependencies = [
 
 [tool.setuptools]
 package-dir = {"" = "Stage_1"}
-packages = {find = {where = ["."], include = ["Stage_1*", "trainer*"]}}
+# All implementation now lives under the `Stage_1` namespace. A dynamic module
+# alias inside ``Stage_1.__init__`` keeps ``python -m trainer.entrypoint``
+# working for legacy job definitions without shipping a separate package.
+packages = {find = {where = ["Stage_1"], include = ["Stage_1*"]}}
 include-package-data = true
 
 [tool.setuptools.package-data]

--- a/vertex/package/Stage_1/trainer/__init__.py
+++ b/vertex/package/Stage_1/trainer/__init__.py
@@ -1,5 +1,0 @@
-"""Vertex AI compatibility layer for the Stage-1 training package."""
-
-from .entrypoint import main
-
-__all__ = ["main"]


### PR DESCRIPTION
## Summary
- remove the standalone `trainer` package and dynamically alias `trainer.entrypoint` from inside `Stage_1`
- update the Vertex entrypoint logging prefix to reflect the Stage_1 namespace
- adjust packaging metadata so only `Stage_1` modules are discovered during builds

## Testing
- python - <<'PY'
import importlib
import sys
sys.path.insert(0, 'vertex/package/Stage_1')

stage1 = importlib.import_module('Stage_1')
trainer = importlib.import_module('trainer.entrypoint')
print('Stage_1 module:', stage1.__name__)
print('trainer entrypoint module:', trainer.__name__)
print('trainer entrypoint main exists:', hasattr(trainer, 'main'))
print('legacy trainer module main same:', sys.modules['trainer'].main is trainer.main)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e9c67ba67083218d9eab9f4a9f1ded