### PR TITLE
Add trainer module shim for Stage_1 Vertex package

### DIFF
--- a/vertex/package/Stage_1/Stage_1/__init__.py
+++ b/vertex/package/Stage_1/Stage_1/__init__.py
@@ -13,7 +13,9 @@ __all__ = ["_cli"]
 
 def _install_trainer_compatibility() -> None:
     """Expose the historic ``trainer`` module path for Vertex AI jobs."""
-    if "trainer.entrypoint" in sys.modules:
+    # If a real ``trainer`` package is already present (for example, the
+    # shims added in this repository), we leave it untouched.
+    if "trainer" in sys.modules or "trainer.entrypoint" in sys.modules:
         return
 
     entrypoint_module = import_module(".vertex.entrypoint", __name__)

--- a/vertex/package/Stage_1/pyproject.toml
+++ b/vertex/package/Stage_1/pyproject.toml
@@ -31,7 +31,7 @@ package-dir = {"" = "Stage_1"}
 # All implementation now lives under the `Stage_1` namespace. A dynamic module
 # alias inside ``Stage_1.__init__`` keeps ``python -m trainer.entrypoint``
 # working for legacy job definitions without shipping a separate package.
-packages = {find = {where = ["Stage_1"], include = ["Stage_1*"]}}
+packages = {find = {where = ["Stage_1"], include = ["Stage_1*", "trainer*"]}}
 include-package-data = true
 
 [tool.setuptools.package-data]

--- a/vertex/package/Stage_1/trainer/__init__.py
+++ b/vertex/package/Stage_1/trainer/__init__.py
@@ -1,0 +1,17 @@
+"""Compatibility package exposing the Stage-1 Vertex entrypoint."""
+
+from __future__ import annotations
+
+from Stage_1.vertex import entrypoint as _entrypoint
+
+__all__ = getattr(_entrypoint, "__all__", tuple())
+
+for _name in __all__:
+    globals()[_name] = getattr(_entrypoint, _name)
+
+if "main" not in __all__ and hasattr(_entrypoint, "main"):
+    main = _entrypoint.main  # type: ignore[assignment]
+    __all__ = tuple(__all__) + ("main",)
+
+# Re-export the entrypoint module for ``python -m trainer.entrypoint``.
+entrypoint = _entrypoint

--- a/vertex/package/Stage_1/trainer/entrypoint.py
+++ b/vertex/package/Stage_1/trainer/entrypoint.py
@@ -1,0 +1,9 @@
+"""Module shim so that ``python -m trainer.entrypoint`` keeps working."""
+
+from __future__ import annotations
+
+from Stage_1.vertex.entrypoint import *  # noqa: F401,F403
+
+# The public surface of ``Stage_1.vertex.entrypoint`` is re-exported so that
+# existing scripts importing ``trainer.entrypoint`` keep functioning without
+# modifications.


### PR DESCRIPTION
## Summary
- ship an explicit `trainer` package that re-exports the Stage-1 Vertex entrypoint so Vertex jobs can import it
- update the Stage-1 package discovery logic to include the new shim and avoid clobbering real modules

## Testing
- PYTHONPATH=vertex/package/Stage_1 python -m trainer.entrypoint --help

------
https://chatgpt.com/codex/tasks/task_e_68e9e88948ec8321a0194c2ba9301fd3