### PR TITLE
Tighten Stage-1 CLI validation and cleanup

### DIFF
--- a/vertex/package/Stage_1/Stage_1/checkpoints/saver.py
+++ b/vertex/package/Stage_1/Stage_1/checkpoints/saver.py
@@ -30,7 +30,15 @@ class BestCheckpointSaver:
             return value < self.best_value
         return value > self.best_value
 
-    def save(self, model: torch.nn.Module, optimizer: torch.optim.Optimizer, scheduler_state: dict, step: int, metrics: dict, freeze_mask: dict | None = None, config: dict | None = None) -> None:
+    def save(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        scheduler_state: dict,
+        step: int,
+        metrics: dict,
+        config: dict | None = None,
+    ) -> None:
         value = metrics.get(self.metric)
         if value is None:
             return
@@ -50,10 +58,6 @@ class BestCheckpointSaver:
                 torch.save(state, fh)
         else:
             torch.save(state, ckpt_path)
-        if freeze_mask is not None:
-            mask_path = os.path.join(self.output_path, "freeze_mask.json")
-            with open_sharded_file(mask_path, "w") as f:
-                json.dump(freeze_mask, f, indent=2, sort_keys=True)
         if config is not None:
             config_path = os.path.join(self.output_path, "config_stage1.json")
             with open_sharded_file(config_path, "w") as f:

--- a/vertex/package/Stage_1/Stage_1/cli.py
+++ b/vertex/package/Stage_1/Stage_1/cli.py
@@ -5,8 +5,70 @@ from __future__ import annotations
 import os
 from datetime import datetime, timezone
 
+from huggingface_hub import HfApi
+from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError
+
 from .trainer import Stage1Trainer
-from .utils import build_arg_parser, build_config, dump_config, ensure_output_path, path_exists
+from .utils import (
+    DEFAULT_DATASET_CFG,
+    build_arg_parser,
+    build_config,
+    dump_config,
+    ensure_output_path,
+    get_hf_token,
+    path_exists,
+)
+
+CANONICAL_TEACHER = "meta-llama/Meta-Llama-3.1-8B"
+TOKEN_ENV_KEYS = ("HF_TOKEN", "HF_API_TOKEN", "HUGGINGFACEHUB_API_TOKEN")
+
+
+def _validate_teacher(name: str) -> None:
+    if name != CANONICAL_TEACHER:
+        raise SystemExit(
+            "Stage-1 distillation requires --teacher_name=meta-llama/Meta-Llama-3.1-8B."
+        )
+
+    token = None
+    for env_key in TOKEN_ENV_KEYS:
+        token = os.getenv(env_key)
+        if token:
+            break
+
+    api = HfApi(token=token)
+    try:
+        api.model_info(name)
+    except RepositoryNotFoundError as exc:  # pragma: no cover - network call
+        raise SystemExit(
+            "Teacher model 'meta-llama/Meta-Llama-3.1-8B' is not available on Hugging Face Hub."
+        ) from exc
+    except HfHubHTTPError as exc:  # pragma: no cover - network call
+        status = getattr(exc.response, "status_code", None)
+        if status in {401, 403}:
+            raise SystemExit(
+                "Access to 'meta-llama/Meta-Llama-3.1-8B' was denied. Ensure your HF token has the required permissions."
+            ) from exc
+        raise SystemExit(
+            f"Failed to validate teacher model 'meta-llama/Meta-Llama-3.1-8B': {exc}"
+        ) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise SystemExit(
+            "Unable to reach Hugging Face Hub to validate the teacher model."
+        ) from exc
+
+
+def _detect_project_id() -> str | None:
+    for env_key in (
+        "AIP_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT",
+        "PROJECT_ID",
+        "CLOUD_ML_PROJECT_ID",
+        "GCLOUD_PROJECT",
+    ):
+        value = os.getenv(env_key)
+        if value:
+            return value
+    return None
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -14,9 +76,35 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     config = build_config(args)
     if not config.resume_gcs_uri:
-        raise SystemExit("Stage-1 requires --resume_gcs_uri=gs://.../stage1.pt")
+        raise SystemExit(
+            "Stage-1 requires --resume_gcs_uri pointing to the post-surgery checkpoint (e.g. gs://liquid-llm-bucket-2/stage1/stage1.pt)."
+        )
     if not path_exists(config.resume_gcs_uri):
         raise SystemExit(f"Checkpoint not found at {config.resume_gcs_uri}")
+    if not config.dataset_cfg:
+        raise SystemExit(
+            f"Stage-1 requires --dataset_cfg pointing to a manifest JSONL (default: {DEFAULT_DATASET_CFG})."
+        )
+    if not path_exists(config.dataset_cfg):
+        raise SystemExit(f"Dataset manifest not found at {config.dataset_cfg}")
+
+    token = None
+    if not any(os.getenv(env_key) for env_key in TOKEN_ENV_KEYS):
+        secret_name = getattr(config, "hf_secret_name", None)
+        if secret_name:
+            try:
+                token = get_hf_token(secret_name, project_id=_detect_project_id())
+            except ValueError as exc:
+                raise SystemExit(f"Unable to resolve HF secret '{secret_name}': {exc}") from exc
+            except Exception as exc:  # pragma: no cover - secret manager/network errors
+                raise SystemExit(
+                    f"Failed to fetch Hugging Face token from secret '{secret_name}': {exc}"
+                ) from exc
+    if token:
+        for env_key in TOKEN_ENV_KEYS:
+            os.environ.setdefault(env_key, token)
+
+    _validate_teacher(config.teacher_name)
     if not config.run_id:
         config.run_id = datetime.now(timezone.utc).strftime("stage1-%Y%m%d-%H%M%S")
     if config.output_gcs_uri:

--- a/vertex/package/Stage_1/Stage_1/runbooks/README_STAGE1.md
+++ b/vertex/package/Stage_1/Stage_1/runbooks/README_STAGE1.md
@@ -17,6 +17,11 @@ Populate the Vertex console form as follows:
 | Command line arguments | Paste the block below |
 | Output directory | `gs://liquid-llm-bucket-2/stage1/checkpoints/vertex_runs` |
 
+The CLI validates the resume checkpoint, teacher model selection, and dataset
+manifest before launching training. It also generates a UTC `run_id` and
+appends it to the output path automatically, so no shell `$(date ...)` logic is
+necessary.
+
 ```
 --resume_gcs_uri=gs://liquid-llm-bucket-2/stage1/stage1.pt
 --output_gcs_uri=gs://liquid-llm-bucket-2/stage1/checkpoints/vertex_runs
@@ -34,4 +39,5 @@ Populate the Vertex console form as follows:
 --hf_secret_name=hf_token
 ```
 
-If you encounter OOMs or throughput is insufficient, upgrade to `a2-highgpu-1g` with an `NVIDIA_A100_40GB` accelerator using the same arguments.
+If you encounter OOMs or throughput is insufficient, upgrade to `a2-highgpu-1g`
+with an `NVIDIA_A100_40GB` accelerator using the same arguments.

--- a/vertex/package/Stage_1/Stage_1/trainer.py
+++ b/vertex/package/Stage_1/Stage_1/trainer.py
@@ -445,7 +445,6 @@ class Stage1Trainer:
                         self.scheduler.state_dict(),
                         step,
                         metrics,
-                        freeze_mask=None,
                         config=config_to_dict(self.config),
                     )
 

--- a/vertex/package/Stage_1/Stage_1/utils/__init__.py
+++ b/vertex/package/Stage_1/Stage_1/utils/__init__.py
@@ -7,6 +7,7 @@ from .config_utils import (
     config_to_dict,
     ensure_output_path,
     dump_config,
+    DEFAULT_DATASET_CFG,
 )
 from .schedule import WarmupCosineScheduler
 from .io import open_sharded_file, path_exists, resolve_glob_paths, write_jsonl
@@ -20,6 +21,7 @@ __all__ = [
     "config_to_dict",
     "ensure_output_path",
     "dump_config",
+    "DEFAULT_DATASET_CFG",
     "WarmupCosineScheduler",
     "open_sharded_file",
     "write_jsonl",

--- a/vertex/package/Stage_1/Stage_1/utils/config_utils.py
+++ b/vertex/package/Stage_1/Stage_1/utils/config_utils.py
@@ -14,6 +14,9 @@ import yaml
 from .io import open_sharded_file
 
 
+DEFAULT_DATASET_CFG = "gs://liquid-llm-bucket-2/datasets/stage1.jsonl"
+
+
 @dataclass
 class Stage1Config:
     """In-memory representation of Stage-1 experiment configuration."""
@@ -24,7 +27,7 @@ class Stage1Config:
     teacher_name: str = "meta-llama/Meta-Llama-3.1-8B"
     teacher_endpoint: Optional[str] = None
     teacher_max_batch_size: int = 0
-    dataset_cfg: Optional[str] = None
+    dataset_cfg: Optional[str] = DEFAULT_DATASET_CFG
     seq_len: int = 1024
     block_size: int = 1024
     train_steps: int = 250_000
@@ -138,7 +141,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--teacher_name", type=str, default="meta-llama/Meta-Llama-3.1-8B")
     parser.add_argument("--teacher_endpoint", type=str, default=None)
     parser.add_argument("--teacher_max_batch_size", type=int, default=0)
-    parser.add_argument("--dataset_cfg", type=str, default=None)
+    parser.add_argument("--dataset_cfg", type=str, default=DEFAULT_DATASET_CFG)
     parser.add_argument("--seq_len", type=int, default=1024)
     parser.add_argument("--block_size", type=int, default=1024)
     parser.add_argument("--train_steps", type=int, default=250_000)
@@ -237,4 +240,5 @@ __all__ = [
     "config_to_dict",
     "ensure_output_path",
     "dump_config",
+    "DEFAULT_DATASET_CFG",
 ]


### PR DESCRIPTION
## Summary
- add explicit dataset and teacher validation in the Stage-1 CLI, including auto-run_id handling and Hugging Face token resolution
- default the dataset manifest path in configuration utilities and export the constant for reuse
- drop unused freeze-mask handling from the checkpoint saver and update the runbook instructions for the cleaned Vertex arguments

## Testing
- python -m compileall vertex/package/Stage_1/Stage_1

------
https://chatgpt.com/codex/tasks/task_e_68e9f7b847c08321a3fdc1537e801240