### PR TITLE
Handle FlashAttention flags in Stage 1 launcher

### DIFF
--- a/vertex/package/Stage_1/Stage_1/launcher.py
+++ b/vertex/package/Stage_1/Stage_1/launcher.py
@@ -1,91 +1,127 @@
-"""Vertex AI launcher that optionally installs FlashAttention at runtime."""
-
-from __future__ import annotations
-
 import argparse
 import glob
 import os
-import subprocess
 import sys
+import subprocess
 import tempfile
 import urllib.request
+from typing import List, Tuple
 
+FA_GCS_FLAG = "--fa_wheel_gcs_uri"
+FA_URL_FLAG = "--fa_wheel_url"
+USE_FA_FLAG = "--use_flash_attn"
 
 def _pip_install(path: str) -> None:
     try:
         subprocess.run([sys.executable, "-m", "pip", "install", path, "--no-deps"], check=False)
         print(f"[launcher] Pip install attempted (non-fatal): {path}")
-    except Exception as exc:  # pragma: no cover - defensive logging only
-        print(f"[launcher] Pip install failed non-fatally: {exc}")
-
+    except Exception as e:
+        print(f"[launcher] Pip install failed non-fatally: {e}")
 
 def _download_gcs(gcs_uri: str, dst_path: str) -> bool:
     try:
         from google.cloud import storage
-
         if not gcs_uri.startswith("gs://"):
             raise ValueError("GCS URI must start with gs://")
-        _, remainder = gcs_uri.split("gs://", 1)
-        bucket_name, blob_name = remainder.split("/", 1)
+        _, rem = gcs_uri.split("gs://", 1)
+        bucket_name, blob_name = rem.split("/", 1)
         client = storage.Client()
         bucket = client.bucket(bucket_name)
         blob = bucket.blob(blob_name)
         blob.download_to_filename(dst_path)
         print(f"[launcher] Downloaded FA wheel from GCS to {dst_path}")
         return True
-    except Exception as exc:  # pragma: no cover - network dependency
-        print(f"[launcher] GCS download failed (non-fatal): {exc}")
+    except Exception as e:
+        print(f"[launcher] GCS download failed (non-fatal): {e}")
         return False
-
 
 def _download_http(url: str, dst_path: str) -> bool:
     try:
-        with urllib.request.urlopen(url) as response, open(dst_path, "wb") as handle:
-            handle.write(response.read())
+        with urllib.request.urlopen(url) as r, open(dst_path, "wb") as f:
+            f.write(r.read())
         print(f"[launcher] Downloaded FA wheel from URL to {dst_path}")
         return True
-    except Exception as exc:  # pragma: no cover - network dependency
-        print(f"[launcher] HTTP download failed (non-fatal): {exc}")
+    except Exception as e:
+        print(f"[launcher] HTTP download failed (non-fatal): {e}")
         return False
 
-
-def maybe_install_flash_attn(enable: bool, gcs_uri: str | None, url: str | None) -> None:
+def _maybe_install_fa(enable: bool, gcs_uri: str, http_url: str) -> None:
     if not enable:
         print("[launcher] FlashAttention disabled by flag.")
         return
-
-    wheel_path = os.path.join(tempfile.gettempdir(), "flash_attn.whl")
-    if gcs_uri and _download_gcs(gcs_uri, wheel_path):
-        _pip_install(wheel_path)
-        return
-
-    if url and _download_http(url, wheel_path):
-        _pip_install(wheel_path)
-        return
-
-    package_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    wheels = sorted(glob.glob(os.path.join(package_root, "wheels", "flash_attn-*.whl")))
+    tmp = os.path.join(tempfile.gettempdir(), "flash_attn.whl")
+    if gcs_uri and _download_gcs(gcs_uri, tmp):
+        _pip_install(tmp); return
+    if http_url and _download_http(http_url, tmp):
+        _pip_install(tmp); return
+    wheels = sorted(glob.glob(os.path.join(os.path.dirname(__file__), "..", "wheels", "flash_attn-*.whl")))
     if wheels:
-        _pip_install(wheels[-1])
-        return
-
+        _pip_install(wheels[-1]); return
     print("[launcher] No FA wheel available; continuing without FlashAttention.")
 
-
-def main() -> None:
+def _parse_launcher_flags(argv: List[str]) -> Tuple[bool, str, str]:
+    """
+    Parse only the launcher's flags from argv (does not error on unknowns).
+    Returns: (use_fa, fa_gcs_uri, fa_url)
+    """
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--use_flash_attn", type=str, default="false")
-    parser.add_argument("--fa_wheel_gcs_uri", type=str, default="")
-    parser.add_argument("--fa_wheel_url", type=str, default="")
-    known, _ = parser.parse_known_args()
+    parser.add_argument(USE_FA_FLAG, type=str, default=os.getenv("STAGE1_USE_FLASH_ATTN", "false"))
+    parser.add_argument(FA_GCS_FLAG, type=str, default=os.getenv("FA_WHEEL_GCS_URI", ""))
+    parser.add_argument(FA_URL_FLAG, type=str, default=os.getenv("FA_WHEEL_URL", ""))
+    known, _ = parser.parse_known_args(argv)
+    use_fa = str(known.use_flash_attn).lower() in {"1", "true", "yes", "y"}
+    return use_fa, known.fa_wheel_gcs_uri, known.fa_wheel_url
 
-    enable = str(known.use_flash_attn).lower() in {"1", "true", "yes", "y"}
-    gcs_uri = known.fa_wheel_gcs_uri or None
-    url = known.fa_wheel_url or None
-    maybe_install_flash_attn(enable, gcs_uri, url)
+def _filtered_argv_for_cli(argv: List[str]) -> List[str]:
+    """
+    Remove the launcher's private flags (and their values) before passing to Stage_1.cli.
+    Supports both '--flag value' and '--flag=value'.
+    Keeps --use_flash_attn, assuming Stage_1.cli accepts it. If your CLI does NOT accept it,
+    toggle KEEP_USE_FA_FLAG = False below to strip it and rely on env var instead.
+    """
+    KEEP_USE_FA_FLAG = True  # set False if Stage_1.cli doesn't accept --use_flash_attn
 
-    os.execv(sys.executable, [sys.executable, "-m", "Stage_1.cli", *sys.argv[1:]])
+    def is_flag_with_value(tok: str, name: str) -> bool:
+        return tok == name or tok.startswith(name + "=")
 
+    out: List[str] = []
+    skip_next = False
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if skip_next:
+            skip_next = False
+            i += 1
+            continue
 
-if __name__ == "__main__":  # pragma: no cover - CLI module
+        if is_flag_with_value(tok, FA_GCS_FLAG) or is_flag_with_value(tok, FA_URL_FLAG):
+            if "=" not in tok and (i + 1) < len(argv) and not argv[i+1].startswith("--"):
+                skip_next = True
+            i += 1
+            continue
+
+        if not KEEP_USE_FA_FLAG and is_flag_with_value(tok, USE_FA_FLAG):
+            if "=" not in tok and (i + 1) < len(argv) and not argv[i+1].startswith("--"):
+                skip_next = True
+            i += 1
+            continue
+
+        out.append(tok)
+        i += 1
+
+    return out
+
+def main():
+    orig_argv = sys.argv[1:]
+    use_fa, fa_gcs_uri, fa_url = _parse_launcher_flags(orig_argv)
+
+    os.environ.setdefault("STAGE1_USE_FLASH_ATTN", "1" if use_fa else "0")
+
+    _maybe_install_fa(use_fa, fa_gcs_uri, fa_url)
+
+    filtered = _filtered_argv_for_cli(orig_argv)
+
+    os.execv(sys.executable, [sys.executable, "-m", "Stage_1.cli", *filtered])
+
+if __name__ == "__main__":
     main()

--- a/vertex/package/Stage_1/Stage_1/runbooks/README_STAGE1.md
+++ b/vertex/package/Stage_1/Stage_1/runbooks/README_STAGE1.md
@@ -7,13 +7,13 @@ Recommended Vertex AI Custom Training configuration:
   - Accelerator: `NVIDIA_L4` (count=1)
   - Container: `us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-4.py310:latest`
   - Local package path: `vertex/package/Stage_1`
-  - Python module: `Stage_1.cli`
+  - Python module: `Stage_1.launcher`
 
 Populate the Vertex console form as follows:
 
 | Field | Value |
 | ----- | ----- |
-| Python module | `Stage_1.cli` |
+| Python module | `Stage_1.launcher` |
 | Command line arguments | Paste the block below |
 | Output directory | `gs://liquid-llm-bucket-2/stage1/checkpoints/vertex_runs` |
 
@@ -33,11 +33,32 @@ necessary.
 --batch_size=8
 --throughput_tokens=32768
 --use_flash_attn=true
+--fa_wheel_gcs_uri=gs://YOUR_BUCKET/wheels/flash_attn-2.5.8-cp310-cp310-manylinux2014_x86_64.whl
 --use_grad_ckpt=true
 --dtype=bfloat16
 --device=cuda
 --hf_secret_name=hf_token
 ```
+
+## FlashAttention wheel handling
+
+The `Stage_1.launcher` module consumes the FlashAttention wheel flags before
+delegating to the training CLI. You can provide either
+`--fa_wheel_gcs_uri=gs://...` or `--fa_wheel_url=https://...` when launching the
+job. The launcher will attempt to download and install the wheel and strip those
+flags from the arguments passed to `Stage_1.cli`, preventing "unrecognized
+arguments" errors.
+
+Environment variables offer the same functionality when CLI flags are
+inconvenient:
+
+- `FA_WHEEL_GCS_URI`
+- `FA_WHEEL_URL`
+- `STAGE1_USE_FLASH_ATTN`
+
+The `STAGE1_USE_FLASH_ATTN` variable mirrors the `--use_flash_attn` flag and is
+automatically set by the launcher, ensuring the trainer maintains the requested
+attention backend even if the CLI flag is omitted.
 
 If you encounter OOMs or throughput is insufficient, upgrade to `a2-highgpu-1g`
 with an `NVIDIA_A100_40GB` accelerator using the same arguments.


### PR DESCRIPTION
## Summary
- replace the Stage_1 launcher with a version that strips FlashAttention wheel flags, installs wheels best-effort, and forwards clean args to the CLI
- allow Stage-1 config parsing to respect the STAGE1_USE_FLASH_ATTN environment fallback while keeping the CLI flag support intact
- document the launcher usage, FlashAttention wheel options, and environment variables in the Stage-1 runbook

## Testing
- PYTHONPATH=vertex/package/Stage_1 python -m Stage_1.cli --help

------
https://chatgpt.com/codex/tasks/task_e_68ea978f4ea08321a2df2426ddfc68de