### PR TITLE
Refine Stage-1 Vertex packaging for Vertex AI compatibility

### DIFF
--- a/vertex/package/Stage_1/Stage_1/cli.py
+++ b/vertex/package/Stage_1/Stage_1/cli.py
@@ -2,121 +2,17 @@
 
 from __future__ import annotations
 
-import os
-from datetime import datetime, timezone
+from typing import Sequence
 
-from huggingface_hub import HfApi
-from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError
-
-from .trainer import Stage1Trainer
-from .utils import (
-    DEFAULT_DATASET_CFG,
-    build_arg_parser,
-    build_config,
-    dump_config,
-    ensure_output_path,
-    get_hf_token,
-    path_exists,
-)
-
-CANONICAL_TEACHER = "meta-llama/Meta-Llama-3.1-8B"
-TOKEN_ENV_KEYS = ("HF_TOKEN", "HF_API_TOKEN", "HUGGINGFACEHUB_API_TOKEN")
+from .vertex.entrypoint import main as _entrypoint_main
 
 
-def _validate_teacher(name: str) -> None:
-    if name != CANONICAL_TEACHER:
-        raise SystemExit(
-            "Stage-1 distillation requires --teacher_name=meta-llama/Meta-Llama-3.1-8B."
-        )
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate to the Vertex entrypoint for backwards compatibility."""
 
-    token = None
-    for env_key in TOKEN_ENV_KEYS:
-        token = os.getenv(env_key)
-        if token:
-            break
-
-    api = HfApi(token=token)
-    try:
-        api.model_info(name)
-    except RepositoryNotFoundError as exc:  # pragma: no cover - network call
-        raise SystemExit(
-            "Teacher model 'meta-llama/Meta-Llama-3.1-8B' is not available on Hugging Face Hub."
-        ) from exc
-    except HfHubHTTPError as exc:  # pragma: no cover - network call
-        status = getattr(exc.response, "status_code", None)
-        if status in {401, 403}:
-            raise SystemExit(
-                "Access to 'meta-llama/Meta-Llama-3.1-8B' was denied. Ensure your HF token has the required permissions."
-            ) from exc
-        raise SystemExit(
-            f"Failed to validate teacher model 'meta-llama/Meta-Llama-3.1-8B': {exc}"
-        ) from exc
-    except Exception as exc:  # pragma: no cover - defensive
-        raise SystemExit(
-            "Unable to reach Hugging Face Hub to validate the teacher model."
-        ) from exc
-
-
-def _detect_project_id() -> str | None:
-    for env_key in (
-        "AIP_PROJECT_ID",
-        "GOOGLE_CLOUD_PROJECT",
-        "PROJECT_ID",
-        "CLOUD_ML_PROJECT_ID",
-        "GCLOUD_PROJECT",
-    ):
-        value = os.getenv(env_key)
-        if value:
-            return value
-    return None
-
-
-def main(argv: list[str] | None = None) -> None:
-    parser = build_arg_parser()
-    args = parser.parse_args(argv)
-    config = build_config(args)
-    if not config.resume_gcs_uri:
-        raise SystemExit(
-            "Stage-1 requires --resume_gcs_uri pointing to the post-surgery checkpoint (e.g. gs://liquid-llm-bucket-2/stage1/stage1.pt)."
-        )
-    if not path_exists(config.resume_gcs_uri):
-        raise SystemExit(f"Checkpoint not found at {config.resume_gcs_uri}")
-    if not config.dataset_cfg:
-        raise SystemExit(
-            f"Stage-1 requires --dataset_cfg pointing to a manifest JSONL (default: {DEFAULT_DATASET_CFG})."
-        )
-    if not path_exists(config.dataset_cfg):
-        raise SystemExit(f"Dataset manifest not found at {config.dataset_cfg}")
-
-    token = None
-    if not any(os.getenv(env_key) for env_key in TOKEN_ENV_KEYS):
-        secret_name = getattr(config, "hf_secret_name", None)
-        if secret_name:
-            try:
-                token = get_hf_token(secret_name, project_id=_detect_project_id())
-            except ValueError as exc:
-                raise SystemExit(f"Unable to resolve HF secret '{secret_name}': {exc}") from exc
-            except Exception as exc:  # pragma: no cover - secret manager/network errors
-                raise SystemExit(
-                    f"Failed to fetch Hugging Face token from secret '{secret_name}': {exc}"
-                ) from exc
-    if token:
-        for env_key in TOKEN_ENV_KEYS:
-            os.environ.setdefault(env_key, token)
-
-    _validate_teacher(config.teacher_name)
-    if not config.run_id:
-        config.run_id = datetime.now(timezone.utc).strftime("stage1-%Y%m%d-%H%M%S")
-    if config.output_gcs_uri:
-        base_uri = config.output_gcs_uri.rstrip("/")
-        config.output_gcs_uri = f"{base_uri}/{config.run_id}"
-    if config.output_gcs_uri and not config.output_gcs_uri.startswith("gs://"):
-        ensure_output_path(config.output_gcs_uri)
-    trainer = Stage1Trainer(config)
-    config_path = os.path.join(trainer.output_path, "config_stage1.json")
-    dump_config(config_path, config)
-    trainer.train()
+    result = _entrypoint_main(argv)
+    return 0 if result is None else result
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    raise SystemExit(main())

--- a/vertex/package/Stage_1/Stage_1/logging_utils.py
+++ b/vertex/package/Stage_1/Stage_1/logging_utils.py
@@ -1,0 +1,42 @@
+"""Logging helpers for Stage-1."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency guard
+    from pythonjsonlogger import jsonlogger
+except Exception:  # pragma: no cover - formatter fallback
+    jsonlogger = None  # type: ignore[assignment]
+
+
+def _build_formatter() -> logging.Formatter:
+    if jsonlogger is not None:
+        return jsonlogger.JsonFormatter("%(levelname)s %(name)s %(message)s")
+    return logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+
+
+def configure_logging(level: int = logging.INFO) -> logging.Logger:
+    """Configure and return the Stage-1 package logger."""
+
+    root = logging.getLogger("Stage_1")
+    if not root.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(_build_formatter())
+        root.addHandler(handler)
+        root.propagate = False
+    root.setLevel(level)
+    return root
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a configured logger scoped under the Stage-1 namespace."""
+
+    root = configure_logging()
+    if not name:
+        return root
+    return root.getChild(name)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/vertex/package/Stage_1/pyproject.toml
+++ b/vertex/package/Stage_1/pyproject.toml
@@ -1,36 +1,41 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "Stage-1"
 version = "0.1.0"
-description = "Stage-1 Vertex AI training package for Liquid LLM"
 requires-python = ">=3.10"
 dependencies = [
-    "transformers==4.57.0",
-    "tokenizers==0.22.1",
-    "datasets==2.20.0",
-    "pyarrow==16.1.0",
-    "huggingface_hub==0.35.3",
-    "accelerate==1.10.1",
-    "google-cloud-secret-manager==2.24.0",
-    "google-cloud-storage==2.18.2",
-    "einops==0.8.0",
-    "numpy==1.26.4",
-    "safetensors==0.6.2",
-    "sentencepiece==0.2.1",
-    "tqdm==4.66.4",
-    "pyyaml==6.0.2",
+  "torch>=2.4.0,<2.5.0",
+  "transformers==4.57.0",
+  "accelerate==1.10.1",
+  "datasets==2.20.0",
+  "sentencepiece>=0.2.0",
+  "safetensors>=0.6.2",
+  "einops>=0.8.0",
+  "google-cloud-storage==2.18.2",
+  "google-cloud-secret-manager==2.24.0",
+  "python-json-logger>=2.0.7",
+  "gcsfs==2025.5.1",
+  "fsspec==2025.5.1",
+  "huggingface_hub>=0.23.2",
+  "numpy>=1.26.4",
+  "pyyaml>=6.0.2",
+  "pyarrow>=16.1.0",
+  "tokenizers>=0.22.1",
+  "tqdm>=4.66.4",
 ]
+
+authors = []
 
 [tool.setuptools]
 package-dir = {"" = "Stage_1"}
-# All implementation now lives under the `Stage_1` namespace. A dynamic module
-# alias inside ``Stage_1.__init__`` keeps ``python -m trainer.entrypoint``
-# working for legacy job definitions without shipping a separate package.
-packages = {find = {where = ["Stage_1"], include = ["Stage_1*", "trainer*"]}}
 include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["Stage_1"]
+include = ["Stage_1*", "trainer*"]
 
 [tool.setuptools.package-data]
 "Stage_1" = [


### PR DESCRIPTION
## Summary
- refactor the Stage-1 Vertex entrypoint to parse CLI arguments directly, install optional FlashAttention wheels, and fetch Hugging Face secrets before launching training
- update the Stage-1 CLI to delegate to the new entrypoint and add JSON logging helpers that tolerate missing python-json-logger
- refresh the Stage-1 pyproject metadata to use setuptools with pinned cloud IO dependencies and ensure package discovery includes the trainer shim

## Testing
- PYTHONPATH=vertex/package/Stage_1 python -m Stage_1.vertex.entrypoint --help
- PYTHONPATH=vertex/package/Stage_1 python -m Stage_1.cli --help
- PYTHONPATH=vertex/package/Stage_1 python -m Stage_1.vertex.entrypoint --resume_gcs_uri=gs://test --output_gcs_uri=gs://test --teacher_name=x --dataset_cfg=gs://test.jsonl


------
https://chatgpt.com/codex/tasks/task_e_68eaac8f4fc083218f8e1a9cac50bb6a