### PR TITLE
Fix Stage_1 logging compatibility for Vertex AI

### DIFF
--- a/vertex/package/Stage_1/.gitignore
+++ b/vertex/package/Stage_1/.gitignore
@@ -1,0 +1,13 @@
+# Ignore large or binary artifacts from training runs
+*.whl
+*.pt
+*.bin
+*.zip
+*.tar
+*.tar.gz
+*.tar.bz2
+*.ckpt
+checkpoints*/
+artifacts*/
+**/checkpoints*/
+**/artifacts*/

--- a/vertex/package/Stage_1/Stage_1/logging_utils.py
+++ b/vertex/package/Stage_1/Stage_1/logging_utils.py
@@ -3,29 +3,60 @@
 from __future__ import annotations
 
 import logging
+from importlib import import_module
+from types import ModuleType
 from typing import Optional
 
-try:  # pragma: no cover - optional dependency guard
-    from pythonjsonlogger import jsonlogger
-except Exception:  # pragma: no cover - formatter fallback
-    jsonlogger = None  # type: ignore[assignment]
+
+def _load_jsonlogger() -> Optional[ModuleType]:  # pragma: no cover - import shim
+    """Return the vendored :mod:`pythonjsonlogger` module if available."""
+
+    candidates = (
+        "Stage_1.pythonjsonlogger.jsonlogger",
+        "pythonjsonlogger.jsonlogger",
+        "pythonjsonlogger",
+    )
+    for path in candidates:
+        try:
+            module = import_module(path)
+        except Exception:
+            continue
+        if hasattr(module, "JsonFormatter"):
+            return module
+    return None
+
+
+_JSONLOGGER = _load_jsonlogger()
 
 
 def _build_formatter() -> logging.Formatter:
-    if jsonlogger is not None:
-        return jsonlogger.JsonFormatter("%(levelname)s %(name)s %(message)s")
+    if _JSONLOGGER is not None:
+        try:
+            return _JSONLOGGER.JsonFormatter("%(levelname)s %(name)s %(message)s")  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - fall back to plain text formatter
+            pass
     return logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+
+
+def _ensure_stream_handler(logger: logging.Logger) -> logging.StreamHandler:
+    for handler in logger.handlers:
+        if isinstance(handler, logging.StreamHandler) and not isinstance(
+            handler, logging.FileHandler
+        ):
+            return handler
+
+    handler = logging.StreamHandler()
+    logger.addHandler(handler)
+    return handler
 
 
 def configure_logging(level: int = logging.INFO) -> logging.Logger:
     """Configure and return the Stage-1 package logger."""
 
     root = logging.getLogger("Stage_1")
-    if not root.handlers:
-        handler = logging.StreamHandler()
-        handler.setFormatter(_build_formatter())
-        root.addHandler(handler)
-        root.propagate = False
+    stream_handler = _ensure_stream_handler(root)
+    stream_handler.setFormatter(_build_formatter())
+    root.propagate = False
     root.setLevel(level)
     return root
 

--- a/vertex/package/Stage_1/pyproject.toml
+++ b/vertex/package/Stage_1/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [tool.setuptools]
 package-dir = {"" = "."}
+include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/vertex/package/Stage_1/pythonjsonlogger/jsonlogger.py
+++ b/vertex/package/Stage_1/pythonjsonlogger/jsonlogger.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -66,6 +67,7 @@ class JsonFormatter(logging.Formatter):
         log_record.setdefault("name", record.name)
         log_record.setdefault("levelname", record.levelname)
         log_record.setdefault("message", record.getMessage())
+        log_record.setdefault("created", getattr(record, "created", time.time()))
         log_record.update(message_dict)
 
     def process_log_record(self, log_record: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- ensure the vendored pythonjsonlogger emits Vertex-compatible timestamps and remains the default formatter
- harden Stage_1 logging setup to avoid duplicate handlers while falling back to stdlib formatting if needed
- include JSONL configs in the package build metadata and add ignores for large artifact outputs

## Testing
- `PYTHONPATH=vertex/package/Stage_1 python - <<'PY'` (exercised configure_logging and JSON output)


------
https://chatgpt.com/codex/tasks/task_e_68eda2b59da483218a3ab72d6c004ecb