### PR TITLE
Add Vertex AI Stage 1 training package

### DIFF
--- a/liquid_llm_vertex_pkg_stage1/README.md
+++ b/liquid_llm_vertex_pkg_stage1/README.md
@@ -1,0 +1,41 @@
+# liquid_llm_vertex_pkg_stage1
+
+This package contains the Stage 1 knowledge distillation training pipeline for Liquid LLM on Google Vertex AI. It supports launching custom training jobs that fine-tune a widened student model from `gs://liquid-llm-bucket-2/stage1/stage1.pt` using teacher guidance from `meta-llama/Llama-3.2-3B`, supervised tool traces, and Vertex-friendly logging and checkpointing.
+
+## Vertex AI Custom Job Configuration
+
+* **Container image:** `us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-4.py310:latest`
+* **Machine type:** `g2-standard-8`
+* **Accelerators:** `1x NVIDIA_L4`
+* **Python package URI:** Point to a GCS location containing the built source distribution of this repository.
+* **Python module:** `stage1.cli`
+
+### Arguments
+
+Paste the following block into the Vertex console **Arguments** field:
+
+```
+--mode=train
+--resume_gcs_uri=gs://liquid-llm-bucket-2/stage1/stage1.pt
+--output_gcs_uri=gs://liquid-llm-bucket-2/stage1/Checkpoints/vertex-runs
+--teacher_id=meta-llama/Llama-3.2-3B
+--teacher_mode=precompute
+--dataset_manifest=gs://liquid-llm-bucket-2/datasets/stage1/manifests/stage1.jsonl
+--seq_len=1024
+--block_size=1024
+--precision=bfloat16
+--lr=2.5e-4 --weight_decay=0.1 --betas=0.9,0.95
+--warmup_steps=3000
+--max_steps=120000
+--eval_every=1000
+--save_every=2000
+--tool_use_ratio=0.08
+--kd_temperature=2.0
+--kd_alpha_start=0.7 --kd_alpha_end=0.4 --kd_anneal_pct=0.3
+--keep_old_logit_l2=0.1 --keep_old_logit_l2_fade_step=30000
+--fa_wheel_gcs=gs://liquid-llm-bucket-2/FlashAttention/flash_attn-2.8.3+cu12torch2.4cxx11abiTRUE-cp310-cp310-linux_x86_64.whl
+```
+
+## Package Layout
+
+The `stage1` package contains modular components for runtime setup, model and teacher loading, data ingest, training, evaluation, tool simulation, and utility helpers. Tests under `tests/` provide lightweight verification of the attention backend selection logic, loss numerics, and tool-use pipeline.

--- a/liquid_llm_vertex_pkg_stage1/requirements.txt
+++ b/liquid_llm_vertex_pkg_stage1/requirements.txt
@@ -1,0 +1,5 @@
+transformers>=4.40.0
+huggingface_hub>=0.23.0
+gcsfs>=2024.1.0
+tqdm>=4.66.0
+numpy>=1.26.0

--- a/liquid_llm_vertex_pkg_stage1/setup.py
+++ b/liquid_llm_vertex_pkg_stage1/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="liquid_llm_vertex_pkg_stage1",
+    version="0.1.0",
+    description="Vertex AI training package for Liquid LLM Stage 1 distillation",
+    author="Liquid LLM Team",
+    packages=find_packages(),
+    install_requires=[
+        "transformers>=4.40.0",
+        "huggingface_hub>=0.23.0",
+        "gcsfs>=2024.1.0",
+        "tqdm>=4.66.0",
+        "numpy>=1.26.0",
+    ],
+    python_requires=">=3.10",
+)

--- a/liquid_llm_vertex_pkg_stage1/stage1/__init__.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/__init__.py
@@ -1,0 +1,5 @@
+"""Stage 1 Vertex AI training package for Liquid LLM."""
+
+from . import cli as _cli  # noqa: F401  (re-export for convenience)
+
+__all__ = ["_cli"]

--- a/liquid_llm_vertex_pkg_stage1/stage1/cli.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/cli.py
@@ -1,0 +1,162 @@
+"""Vertex AI entrypoint."""
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+from . import runtime_setup
+from .data import DataModule
+from .model_init import load_student_model
+from .teacher import load_teacher, load_teacher_tokenizer, precompute_teacher_logits
+from .train import TeacherProvider, TrainingConfig, train
+from .utils import parse_betas, set_seed, str2bool
+
+DEFAULT_FA_WHEEL = "gs://liquid-llm-bucket-2/FlashAttention/flash_attn-2.8.3+cu12torch2.4cxx11abiTRUE-cp310-cp310-linux_x86_64.whl"
+DEFAULT_RESUME = "gs://liquid-llm-bucket-2/stage1/stage1.pt"
+DEFAULT_MANIFEST = "gs://liquid-llm-bucket-2/datasets/stage1/manifests/stage1.jsonl"
+DEFAULT_OUTPUT = "gs://liquid-llm-bucket-2/stage1/Checkpoints/vertex-runs"
+DEFAULT_LOGITS_DIR = "gs://liquid-llm-bucket-2/teacher/llama-3.2-3b/logits/"
+
+LOGGER = logging.getLogger(__name__)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Liquid LLM Stage 1 Vertex trainer")
+    parser.add_argument("--mode", choices=["train", "precompute_teacher_logits"], default="train")
+    parser.add_argument("--resume_gcs_uri", default=DEFAULT_RESUME)
+    parser.add_argument("--output_gcs_uri", default=DEFAULT_OUTPUT)
+    parser.add_argument("--dataset_manifest", default=DEFAULT_MANIFEST)
+    parser.add_argument("--teacher_id", default="meta-llama/Llama-3.2-3B")
+    parser.add_argument("--teacher_mode", choices=["online", "precompute"], default="precompute")
+    parser.add_argument("--fa_wheel_gcs", default=DEFAULT_FA_WHEEL)
+    parser.add_argument("--seq_len", type=int, default=1024)
+    parser.add_argument("--block_size", type=int, default=1024)
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--precision", choices=["bfloat16", "float16"], default="bfloat16")
+    parser.add_argument("--lr", type=float, default=2.5e-4)
+    parser.add_argument("--weight_decay", type=float, default=0.1)
+    parser.add_argument("--betas", type=parse_betas, default=(0.9, 0.95))
+    parser.add_argument("--warmup_steps", type=int, default=3000)
+    parser.add_argument("--max_steps", type=int, default=120000)
+    parser.add_argument("--eval_every", type=int, default=1000)
+    parser.add_argument("--save_every", type=int, default=2000)
+    parser.add_argument("--kd_temperature", type=float, default=2.0)
+    parser.add_argument("--kd_alpha_start", type=float, default=0.7)
+    parser.add_argument("--kd_alpha_end", type=float, default=0.4)
+    parser.add_argument("--kd_anneal_pct", type=float, default=0.3)
+    parser.add_argument("--keep_old_logit_l2", type=float, default=0.1)
+    parser.add_argument("--keep_old_logit_l2_fade_step", type=int, default=30000)
+    parser.add_argument("--tool_use_ratio", type=float, default=0.08)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--log_dir", default="/tmp/logs")
+    parser.add_argument("--tb_dir", default="/tmp/tensorboard")
+    parser.add_argument("--tb_gcs_uri", default="gs://liquid-llm-bucket-2/logs/tb/")
+    parser.add_argument("--logits_dir", default=DEFAULT_LOGITS_DIR)
+    parser.add_argument("--cache_dir", default="/cache/hf")
+    parser.add_argument("--run_id", default=None)
+    parser.add_argument("--teacher_batch_size", type=int, default=4)
+    parser.add_argument("--teacher_seq_len", type=int, default=1024)
+    parser.add_argument("--teacher_precision", choices=["bfloat16", "float16"], default="bfloat16")
+    parser.add_argument("--base_model_id", default="meta-llama/Llama-3.1-8B")
+    parser.add_argument("--width_scale", type=float, default=1.2)
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    set_seed(args.seed)
+
+    if args.mode == "precompute_teacher_logits":
+        dtype = torch.bfloat16 if args.teacher_precision == "bfloat16" else torch.float16
+        precompute_teacher_logits(
+            manifest_uri=args.dataset_manifest,
+            output_dir=args.logits_dir,
+            model_id=args.teacher_id,
+            dtype=dtype,
+            batch_size=args.teacher_batch_size,
+            seq_len=args.teacher_seq_len,
+        )
+        return
+
+    dtype = runtime_setup.setup_runtime(args.fa_wheel_gcs, precision=args.precision)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, _ = load_student_model(
+        resume_gcs_uri=args.resume_gcs_uri,
+        device=device,
+        precision=args.precision,
+        base_model_id=args.base_model_id,
+        width_scale=args.width_scale,
+    )
+
+    teacher_model = None
+    if args.teacher_mode == "online":
+        teacher_model, tokenizer = load_teacher(model_id=args.teacher_id, dtype=dtype, cache_dir=args.cache_dir)
+    else:
+        tokenizer = load_teacher_tokenizer(model_id=args.teacher_id, cache_dir=args.cache_dir)
+
+    datamodule = DataModule(
+        manifest_uri=args.dataset_manifest,
+        tokenizer=tokenizer,
+        block_size=args.block_size,
+        batch_size=args.batch_size,
+        seed=args.seed,
+        tool_use_ratio=args.tool_use_ratio,
+    )
+
+    run_id = args.run_id or time.strftime("%Y%m%d-%H%M%S")
+    log_path = Path(args.log_dir) / f"{run_id}.log"
+    tb_path = Path(args.tb_dir) / run_id
+
+    config = TrainingConfig(
+        learning_rate=args.lr,
+        betas=args.betas,
+        weight_decay=args.weight_decay,
+        warmup_steps=args.warmup_steps,
+        max_steps=args.max_steps,
+        eval_every=args.eval_every,
+        save_every=args.save_every,
+        kd_temperature=args.kd_temperature,
+        kd_alpha_start=args.kd_alpha_start,
+        kd_alpha_end=args.kd_alpha_end,
+        kd_anneal_pct=args.kd_anneal_pct,
+        keep_old_logit_l2=args.keep_old_logit_l2,
+        keep_old_logit_l2_fade_step=args.keep_old_logit_l2_fade_step,
+        output_gcs_uri=args.output_gcs_uri,
+        run_id=run_id,
+        precision=args.precision,
+    )
+
+    teacher_provider = TeacherProvider(
+        mode=args.teacher_mode,
+        logits_dir=args.logits_dir,
+        teacher_model=teacher_model,
+    )
+
+    train(
+        model=model,
+        datamodule=datamodule,
+        device=device,
+        teacher_provider=teacher_provider,
+        config=config,
+        precision_dtype=dtype,
+        log_path=log_path,
+        tensorboard_dir=tb_path,
+    )
+
+    gcs_target = f"{args.tb_gcs_uri.rstrip('/')}/{run_id}"
+    try:
+        from . import gcs_io
+
+        gcs_io.gcs_cp(str(tb_path), gcs_target, recursive=True)
+    except Exception as exc:  # pragma: no cover - best effort
+        LOGGER.warning("Failed to upload TensorBoard logs: %s", exc)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/liquid_llm_vertex_pkg_stage1/stage1/data.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/data.py
@@ -1,0 +1,186 @@
+"""Data loading utilities for Stage 1 training."""
+
+import json
+import logging
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List
+
+if TYPE_CHECKING:  # pragma: no cover
+    import gcsfs
+
+import torch
+from torch.utils.data import DataLoader, IterableDataset
+from transformers import PreTrainedTokenizerBase
+
+from .tool_use.traces import maybe_inject_tool_result
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ManifestEntry:
+    path: str
+    type: str
+    weight: float
+
+
+def load_manifest(manifest_uri: str) -> List[ManifestEntry]:
+    import gcsfs
+
+    fs = gcsfs.GCSFileSystem()
+    entries: List[ManifestEntry] = []
+    LOGGER.info("Loading manifest from %s", manifest_uri)
+    with fs.open(manifest_uri, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            entries.append(
+                ManifestEntry(
+                    path=payload["path"],
+                    type=payload.get("type", "lm"),
+                    weight=float(payload.get("weight", 1.0)),
+                )
+            )
+    return entries
+
+
+def resolve_paths(fs: "gcsfs.GCSFileSystem", pattern: str) -> List[str]:
+    if any(token in pattern for token in "*?[]"):
+        return fs.glob(pattern)
+    return [pattern]
+
+
+def iter_jsonl(fs: "gcsfs.GCSFileSystem", gcs_path: str) -> Iterator[Dict[str, str]]:
+    with fs.open(gcs_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def tokenize_and_pack(
+    tokenizer: PreTrainedTokenizerBase,
+    texts: Iterable[str],
+    block_size: int,
+) -> Iterator[Dict[str, torch.Tensor]]:
+    buffer: List[int] = []
+    eos_id = tokenizer.eos_token_id
+    for text in texts:
+        ids = tokenizer.encode(text, add_special_tokens=False)
+        if eos_id is not None:
+            ids = ids + [eos_id]
+        buffer.extend(ids)
+        while len(buffer) >= block_size + 1:
+            input_ids = buffer[:block_size]
+            labels = buffer[1 : block_size + 1]
+            buffer = buffer[block_size:]
+            attention_mask = [1] * block_size
+            yield {
+                "input_ids": torch.tensor(input_ids, dtype=torch.long),
+                "labels": torch.tensor(labels, dtype=torch.long),
+                "attention_mask": torch.tensor(attention_mask, dtype=torch.long),
+            }
+
+
+class PackedDataset(IterableDataset):
+    def __init__(
+        self,
+        entries: List[ManifestEntry],
+        tokenizer: PreTrainedTokenizerBase,
+        block_size: int,
+        seed: int = 42,
+        tool_use_ratio: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.entries = entries
+        self.tokenizer = tokenizer
+        self.block_size = block_size
+        self.seed = seed
+        self.tool_use_ratio = tool_use_ratio
+        import gcsfs
+
+        self.fs = gcsfs.GCSFileSystem()
+
+    def _stream_entry(self, entry: ManifestEntry) -> Iterator[Dict[str, torch.Tensor]]:
+        paths = resolve_paths(self.fs, entry.path)
+        rng = random.Random(self.seed)
+        rng.shuffle(paths)
+
+        def text_iter() -> Iterator[str]:
+            for path in paths:
+                for row in iter_jsonl(self.fs, path):
+                    text = row.get("text", "")
+                    if entry.type == "math_tool" and rng.random() <= self.tool_use_ratio:
+                        text = maybe_inject_tool_result(text)
+                    yield text
+
+        return tokenize_and_pack(self.tokenizer, text_iter(), self.block_size)
+
+    def __iter__(self) -> Iterator[Dict[str, torch.Tensor]]:
+        rng = random.Random(self.seed)
+        iterators: Dict[str, Iterator[Dict[str, torch.Tensor]]] = {}
+        weights = [entry.weight for entry in self.entries]
+        if not weights:
+            return iter([])
+        while True:
+            entry = rng.choices(self.entries, weights=weights, k=1)[0]
+            key = entry.path
+            if key not in iterators:
+                iterators[key] = self._stream_entry(entry)
+            try:
+                yield next(iterators[key])
+            except StopIteration:
+                iterators[key] = self._stream_entry(entry)
+                yield next(iterators[key])
+
+
+class DataModule:
+    def __init__(
+        self,
+        manifest_uri: str,
+        tokenizer: PreTrainedTokenizerBase,
+        block_size: int,
+        batch_size: int,
+        seed: int = 42,
+        tool_use_ratio: float = 0.0,
+    ) -> None:
+        self.entries = load_manifest(manifest_uri)
+        self.tokenizer = tokenizer
+        self.block_size = block_size
+        self.batch_size = batch_size
+        self.seed = seed
+        self.tool_use_ratio = tool_use_ratio
+
+    def train_dataloader(self) -> DataLoader:
+        dataset = PackedDataset(
+            self.entries,
+            tokenizer=self.tokenizer,
+            block_size=self.block_size,
+            seed=self.seed,
+            tool_use_ratio=self.tool_use_ratio,
+        )
+        return DataLoader(dataset, batch_size=self.batch_size)
+
+    def val_dataloader(self) -> DataLoader:
+        dataset = PackedDataset(
+            self.entries[: max(1, len(self.entries) // 10)],
+            tokenizer=self.tokenizer,
+            block_size=self.block_size,
+            seed=self.seed + 1,
+            tool_use_ratio=self.tool_use_ratio,
+        )
+        return DataLoader(dataset, batch_size=self.batch_size)
+
+
+__all__ = [
+    "DataModule",
+    "load_manifest",
+    "ManifestEntry",
+    "resolve_paths",
+    "iter_jsonl",
+    "tokenize_and_pack",
+]

--- a/liquid_llm_vertex_pkg_stage1/stage1/eval.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/eval.py
@@ -1,0 +1,58 @@
+"""Evaluation helpers."""
+
+import logging
+from typing import Dict, Tuple
+
+import torch
+from torch.utils.data import DataLoader
+
+LOGGER = logging.getLogger(__name__)
+
+
+def evaluate_perplexity(model: torch.nn.Module, dataloader: DataLoader, device: torch.device) -> float:
+    model.eval()
+    losses = []
+    with torch.no_grad():
+        for batch in dataloader:
+            input_ids = batch["input_ids"].to(device)
+            labels = batch["labels"].to(device)
+            attention_mask = batch.get("attention_mask")
+            if attention_mask is not None:
+                attention_mask = attention_mask.to(device)
+            outputs = model(input_ids=input_ids, attention_mask=attention_mask, labels=labels)
+            losses.append(outputs.loss.item())
+    model.train()
+    if not losses:
+        return float("inf")
+    mean_loss = sum(losses) / len(losses)
+    return float(torch.exp(torch.tensor(mean_loss)))
+
+
+def evaluate_tool_accuracy(model: torch.nn.Module, dataloader: DataLoader, device: torch.device) -> float:
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for batch in dataloader:
+            input_ids = batch["input_ids"].to(device)
+            labels = batch["labels"].to(device)
+            logits = model(input_ids=input_ids).logits
+            preds = logits.argmax(dim=-1)
+            match = (preds == labels).float()
+            correct += match.mean().item()
+            total += 1
+    model.train()
+    if total == 0:
+        return 0.0
+    return correct / total
+
+
+def run_eval(model: torch.nn.Module, datamodule, device: torch.device) -> Dict[str, float]:
+    ppl = evaluate_perplexity(model, datamodule.val_dataloader(), device)
+    acc = evaluate_tool_accuracy(model, datamodule.val_dataloader(), device)
+    metrics = {"perplexity": ppl, "tool_accuracy": acc}
+    LOGGER.info("Eval metrics: %s", metrics)
+    return metrics
+
+
+__all__ = ["run_eval", "evaluate_perplexity", "evaluate_tool_accuracy"]

--- a/liquid_llm_vertex_pkg_stage1/stage1/gcs_io.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/gcs_io.py
@@ -1,0 +1,60 @@
+"""Helpers for interacting with Google Cloud Storage via gcloud."""
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Iterable, List
+
+LOGGER = logging.getLogger(__name__)
+
+
+def gcs_cp(src: str, dst: str, recursive: bool = False) -> None:
+    cmd = ["gcloud", "storage", "cp"]
+    if recursive:
+        cmd.append("-r")
+    cmd.extend([src, dst])
+    LOGGER.info("Running: %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def download_to_path(gcs_uri: str, local_path: Path) -> Path:
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    gcs_cp(gcs_uri, str(local_path))
+    return local_path
+
+
+def upload_file(local_path: Path, gcs_uri: str) -> None:
+    gcs_cp(str(local_path), gcs_uri)
+
+
+def upload_logs_periodically(log_path: Path, gcs_uri: str) -> None:
+    if not log_path.exists():
+        LOGGER.debug("Log path %s does not exist; skipping upload.", log_path)
+        return
+    upload_file(log_path, gcs_uri)
+
+
+def list_gcs(glob_uri: str) -> List[str]:
+    cmd = ["gcloud", "storage", "ls", glob_uri]
+    LOGGER.info("Listing GCS files: %s", glob_uri)
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def download_many(gcs_uris: Iterable[str], dst_dir: Path) -> List[Path]:
+    paths = []
+    for uri in gcs_uris:
+        local = dst_dir / Path(uri).name
+        download_to_path(uri, local)
+        paths.append(local)
+    return paths
+
+
+__all__ = [
+    "gcs_cp",
+    "download_to_path",
+    "upload_file",
+    "upload_logs_periodically",
+    "list_gcs",
+    "download_many",
+]

--- a/liquid_llm_vertex_pkg_stage1/stage1/losses.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/losses.py
@@ -1,0 +1,85 @@
+"""Loss functions for Stage 1 training."""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+LOGGER = logging.getLogger(__name__)
+
+
+def kd_loss(student_logits: torch.Tensor, teacher_logits: torch.Tensor, temperature: float) -> torch.Tensor:
+    t = temperature
+    student_log_probs = F.log_softmax(student_logits / t, dim=-1)
+    teacher_probs = F.softmax(teacher_logits / t, dim=-1)
+    loss = F.kl_div(student_log_probs, teacher_probs, reduction="batchmean") * (t ** 2)
+    return loss
+
+
+def ce_loss(student_logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    vocab = student_logits.size(-1)
+    loss = F.cross_entropy(student_logits.view(-1, vocab), labels.view(-1), ignore_index=-100)
+    return loss
+
+
+def logit_l2_loss(student_logits: torch.Tensor, baseline_logits: torch.Tensor) -> torch.Tensor:
+    return F.mse_loss(student_logits, baseline_logits)
+
+
+@dataclass
+class LossMixer:
+    kd_alpha_start: float = 0.7
+    kd_alpha_end: float = 0.4
+    kd_anneal_pct: float = 0.3
+
+    def weights(self, step: int, total_steps: int) -> torch.Tensor:
+        progress = step / max(1, total_steps)
+        if progress > self.kd_anneal_pct:
+            frac = 1.0
+        else:
+            frac = progress / max(self.kd_anneal_pct, 1e-6)
+        alpha = self.kd_alpha_start + (self.kd_alpha_end - self.kd_alpha_start) * frac
+        beta = 1.0 - alpha
+        return torch.tensor([alpha, beta])
+
+    def mix(
+        self,
+        kd_component: torch.Tensor,
+        ce_component: torch.Tensor,
+        step: int,
+        total_steps: int,
+    ) -> torch.Tensor:
+        alpha, beta = self.weights(step, total_steps)
+        return alpha.item() * kd_component + beta.item() * ce_component
+
+
+def combined_loss(
+    student_logits: torch.Tensor,
+    teacher_logits: torch.Tensor,
+    labels: torch.Tensor,
+    step: int,
+    total_steps: int,
+    mixer: LossMixer,
+    temperature: float,
+    baseline_logits: Optional[torch.Tensor] = None,
+    baseline_weight: float = 0.0,
+    baseline_fade_step: int = 0,
+) -> torch.Tensor:
+    kd_component = kd_loss(student_logits, teacher_logits, temperature)
+    ce_component = ce_loss(student_logits, labels)
+    loss = mixer.mix(kd_component, ce_component, step, total_steps)
+    if baseline_logits is not None and baseline_weight > 0.0 and step <= baseline_fade_step:
+        decay = 1.0 - (step / max(1, baseline_fade_step))
+        loss = loss + baseline_weight * decay * logit_l2_loss(student_logits, baseline_logits)
+    return loss
+
+
+__all__ = [
+    "kd_loss",
+    "ce_loss",
+    "logit_l2_loss",
+    "LossMixer",
+    "combined_loss",
+]

--- a/liquid_llm_vertex_pkg_stage1/stage1/model_init.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/model_init.py
@@ -1,0 +1,66 @@
+"""Student model loading and precision helpers."""
+
+import logging
+from pathlib import Path
+from typing import Tuple
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from . import gcs_io
+
+LOGGER = logging.getLogger(__name__)
+
+
+def determine_dtype(precision: str) -> torch.dtype:
+    if precision == "float16":
+        return torch.float16
+    return torch.bfloat16
+
+
+def get_autocast(dtype: torch.dtype):
+    target_dtype = torch.bfloat16 if dtype == torch.bfloat16 else torch.float16
+    return torch.cuda.amp.autocast(dtype=target_dtype)
+
+
+def load_student_model(
+    resume_gcs_uri: str,
+    device: torch.device,
+    precision: str = "bfloat16",
+    base_model_id: str = "meta-llama/Llama-3.1-8B",
+    width_scale: float = 1.2,
+    cache_dir: str = "/cache/student",
+) -> Tuple[torch.nn.Module, torch.dtype]:
+    Path(cache_dir).mkdir(parents=True, exist_ok=True)
+    local_ckpt = Path(cache_dir) / "stage1.pt"
+    LOGGER.info("Downloading student checkpoint from %s", resume_gcs_uri)
+    gcs_io.download_to_path(resume_gcs_uri, local_ckpt)
+    LOGGER.info("Loading student base config %s", base_model_id)
+    config = AutoConfig.from_pretrained(base_model_id)
+    if hasattr(config, "intermediate_size"):
+        config.intermediate_size = int(config.intermediate_size * width_scale)
+    if hasattr(config, "num_hidden_layers"):
+        config.num_hidden_layers = config.num_hidden_layers + 1
+    model = AutoModelForCausalLM.from_config(config)
+    state_dict = torch.load(local_ckpt, map_location="cpu")
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if missing:
+        LOGGER.info("Missing keys when loading student: %s", missing[:10])
+    if unexpected:
+        LOGGER.info("Unexpected keys when loading student: %s", unexpected[:10])
+    dtype = determine_dtype(precision)
+    model.to(device=device, dtype=dtype)
+    if hasattr(model, "gradient_checkpointing_enable"):
+        model.gradient_checkpointing_enable()
+    for module in model.modules():
+        if hasattr(module, "gradient_checkpointing"):
+            try:
+                module.gradient_checkpointing = True
+            except Exception:  # pragma: no cover - best effort
+                pass
+    model.train()
+    LOGGER.info("Student model ready on %s with dtype %s", device, dtype)
+    return model, dtype
+
+
+__all__ = ["load_student_model", "determine_dtype", "get_autocast"]

--- a/liquid_llm_vertex_pkg_stage1/stage1/runtime_setup.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/runtime_setup.py
@@ -1,0 +1,102 @@
+"""Runtime setup utilities for Vertex AI jobs."""
+
+import importlib
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import torch
+from huggingface_hub import login
+
+LOGGER = logging.getLogger(__name__)
+
+
+def login_to_huggingface() -> None:
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        raise EnvironmentError("HF_TOKEN environment variable must be set for Hugging Face login.")
+    login(token=token, add_to_git_credential=False)
+    LOGGER.info("Authenticated to Hugging Face Hub.")
+
+
+def download_flashattention(wheel_gcs_uri: str, dst_dir: Path) -> Path:
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    wheel_path = dst_dir / Path(wheel_gcs_uri).name
+    if wheel_path.exists():
+        LOGGER.info("FlashAttention wheel already present at %s", wheel_path)
+        return wheel_path
+    cmd = [
+        "gcloud",
+        "storage",
+        "cp",
+        wheel_gcs_uri,
+        str(wheel_path),
+    ]
+    LOGGER.info("Downloading FlashAttention wheel from %s", wheel_gcs_uri)
+    subprocess.run(cmd, check=True)
+    return wheel_path
+
+
+def install_wheel(wheel_path: Path) -> None:
+    LOGGER.info("Installing wheel %s", wheel_path)
+    subprocess.run([sys.executable, "-m", "pip", "install", str(wheel_path)], check=True)
+
+
+def try_import_flashattention() -> Optional[object]:
+    try:
+        return importlib.import_module("flash_attn")
+    except Exception as exc:  # pragma: no cover - defensive
+        LOGGER.warning("FlashAttention import failed: %s", exc)
+        return None
+
+
+def configure_attention_backend(flash_mod: Optional[object]) -> None:
+    if not torch.cuda.is_available():
+        LOGGER.warning("CUDA not available; attention backend configuration skipped.")
+        return
+    if flash_mod is not None:
+        LOGGER.info("FlashAttention available: %s", flash_mod.__name__)
+        torch.backends.cuda.enable_flash_sdp(True)
+        torch.backends.cuda.enable_mem_efficient_sdp(True)
+        torch.backends.cuda.enable_math_sdp(False)
+        return
+
+    LOGGER.info("Falling back to PyTorch SDPA backends.")
+    torch.backends.cuda.enable_flash_sdp(True)
+    torch.backends.cuda.enable_mem_efficient_sdp(True)
+    torch.backends.cuda.enable_math_sdp(False)
+
+
+def setup_runtime(wheel_gcs_uri: str, precision: str = "bfloat16") -> torch.dtype:
+    login_to_huggingface()
+    wheel_dir = Path("/tmp/wheels")
+    try:
+        wheel_path = download_flashattention(wheel_gcs_uri, wheel_dir)
+        install_wheel(wheel_path)
+    except subprocess.CalledProcessError as exc:
+        LOGGER.warning("Failed to install FlashAttention: %s", exc)
+    flash_mod = try_import_flashattention()
+    configure_attention_backend(flash_mod)
+    dtype = torch.bfloat16 if precision == "bfloat16" else torch.float16
+    LOGGER.info("Using precision %s (dtype=%s)", precision, dtype)
+    return dtype
+
+
+def autocast_context(dtype: torch.dtype):
+    if dtype == torch.bfloat16:
+        return torch.cuda.amp.autocast(dtype=torch.bfloat16)
+    return torch.cuda.amp.autocast(dtype=torch.float16)
+
+
+__all__ = [
+    "setup_runtime",
+    "autocast_context",
+    "login_to_huggingface",
+    "download_flashattention",
+    "install_wheel",
+    "try_import_flashattention",
+    "configure_attention_backend",
+]

--- a/liquid_llm_vertex_pkg_stage1/stage1/teacher.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/teacher.py
@@ -1,0 +1,94 @@
+"""Teacher model utilities."""
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, List
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from .data import load_manifest, resolve_paths, iter_jsonl
+
+LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    import gcsfs
+
+
+def load_teacher(
+    model_id: str = "meta-llama/Llama-3.2-3B",
+    dtype: torch.dtype = torch.bfloat16,
+    cache_dir: str = "/cache/hf",
+):
+    LOGGER.info("Loading teacher model %s", model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id, cache_dir=cache_dir)
+    model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=dtype, cache_dir=cache_dir)
+    model.to("cuda")
+    model.eval()
+    return model, tokenizer
+
+
+def load_teacher_tokenizer(
+    model_id: str = "meta-llama/Llama-3.2-3B",
+    cache_dir: str = "/cache/hf",
+):
+    LOGGER.info("Loading teacher tokenizer %s", model_id)
+    return AutoTokenizer.from_pretrained(model_id, cache_dir=cache_dir)
+
+
+def precompute_teacher_logits(
+    manifest_uri: str,
+    output_dir: str = "gs://liquid-llm-bucket-2/teacher/llama-3.2-3b/logits/",
+    model_id: str = "meta-llama/Llama-3.2-3B",
+    dtype: torch.dtype = torch.bfloat16,
+    batch_size: int = 4,
+    seq_len: int = 1024,
+) -> None:
+    model, tokenizer = load_teacher(model_id=model_id, dtype=dtype)
+    import gcsfs
+
+    fs = gcsfs.GCSFileSystem()
+    manifest = load_manifest(manifest_uri)
+    shard_idx = 0
+    for entry in manifest:
+        paths = resolve_paths(fs, entry.path)
+        for path in paths:
+            LOGGER.info("Precomputing logits for %s", path)
+            tokens: List[List[int]] = []
+            for row in iter_jsonl(fs, path):
+                text = row.get("text", "")
+                tokens_ids = tokenizer.encode(text, add_special_tokens=False)
+                tokens_ids = tokens_ids[: seq_len - 1]
+                eos_id = tokenizer.eos_token_id or tokenizer.pad_token_id
+                pad_id = tokenizer.pad_token_id or eos_id
+                tokens_ids.append(eos_id)
+                if len(tokens_ids) < seq_len:
+                    tokens_ids = tokens_ids + [pad_id] * (seq_len - len(tokens_ids))
+                tokens.append(tokens_ids)
+                if len(tokens) == batch_size:
+                    _flush_logits(model, tokens, shard_idx, output_dir)
+                    shard_idx += 1
+                    tokens = []
+            if tokens:
+                _flush_logits(model, tokens, shard_idx, output_dir)
+                shard_idx += 1
+
+
+def _flush_logits(model, batch_tokens: List[List[int]], shard_idx: int, output_dir: str) -> None:
+    import gcsfs
+
+    fs = gcsfs.GCSFileSystem()
+    input_ids = torch.tensor(batch_tokens, device="cuda")
+    with torch.no_grad():
+        logits = model(input_ids=input_ids).logits.cpu()
+    for seq_tokens, seq_logits in zip(batch_tokens, logits):
+        key = hashlib.sha1(torch.tensor(seq_tokens, dtype=torch.int64).numpy().tobytes()).hexdigest()
+        local_path = Path("/tmp") / f"{key}.pt"
+        torch.save({"logits": seq_logits, "input_ids": torch.tensor(seq_tokens)}, local_path)
+        target_uri = f"{output_dir.rstrip('/')}/{key}.pt"
+        LOGGER.info("Writing teacher logits shard %s", target_uri)
+        fs.put(str(local_path), target_uri)
+
+
+__all__ = ["load_teacher", "load_teacher_tokenizer", "precompute_teacher_logits"]

--- a/liquid_llm_vertex_pkg_stage1/stage1/tool_use/__init__.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/tool_use/__init__.py
@@ -1,0 +1,14 @@
+"""Tool use helpers for training."""
+
+from .calculator import SafeCalculator
+from .scratchpad import Scratchpad
+from .registry import TOOL_REGISTRY, call_tool
+from .traces import maybe_inject_tool_result
+
+__all__ = [
+    "SafeCalculator",
+    "Scratchpad",
+    "TOOL_REGISTRY",
+    "call_tool",
+    "maybe_inject_tool_result",
+]

--- a/liquid_llm_vertex_pkg_stage1/stage1/tool_use/calculator.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/tool_use/calculator.py
@@ -1,0 +1,46 @@
+"""Safe scientific calculator for tool supervision."""
+
+import math
+from typing import Any, Dict
+
+_ALLOWED_NAMES: Dict[str, Any] = {
+    name: getattr(math, name)
+    for name in [
+        "pi",
+        "e",
+        "tau",
+        "inf",
+        "nan",
+        "sin",
+        "cos",
+        "tan",
+        "log",
+        "log10",
+        "exp",
+        "sqrt",
+        "floor",
+        "ceil",
+        "fabs",
+    ]
+}
+_ALLOWED_NAMES.update({"abs": abs, "round": round})
+
+
+class SafeCalculator:
+    """Evaluates mathematical expressions with a strict whitelist."""
+
+    def __init__(self):
+        self._globals = {"__builtins__": {}}
+        self._locals = dict(_ALLOWED_NAMES)
+
+    def evaluate(self, expression: str) -> str:
+        expression = expression.strip()
+        if not expression:
+            raise ValueError("Empty expression")
+        result = eval(expression, self._globals, self._locals)  # noqa: S307 - controlled environment
+        if isinstance(result, float):
+            return f"{result:.8g}"
+        return str(result)
+
+
+__all__ = ["SafeCalculator"]

--- a/liquid_llm_vertex_pkg_stage1/stage1/tool_use/registry.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/tool_use/registry.py
@@ -1,0 +1,28 @@
+"""Registry of available tools."""
+
+from typing import Callable, Dict
+
+from .calculator import SafeCalculator
+from .scratchpad import Scratchpad
+
+_CALCULATOR = SafeCalculator()
+_SCRATCHPAD = Scratchpad()
+
+TOOL_REGISTRY: Dict[str, Callable[[str], str]] = {
+    "calculator": _CALCULATOR.evaluate,
+    "scratchpad_append": lambda text: _register_scratchpad(text),
+}
+
+
+def _register_scratchpad(text: str) -> str:
+    _SCRATCHPAD.add(text)
+    return _SCRATCHPAD.render()
+
+
+def call_tool(name: str, arg: str) -> str:
+    if name not in TOOL_REGISTRY:
+        raise KeyError(f"Unknown tool: {name}")
+    return TOOL_REGISTRY[name](arg)
+
+
+__all__ = ["TOOL_REGISTRY", "call_tool"]

--- a/liquid_llm_vertex_pkg_stage1/stage1/tool_use/scratchpad.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/tool_use/scratchpad.py
@@ -1,0 +1,20 @@
+"""Scratchpad helper for tool demonstrations."""
+
+from typing import List
+
+
+class Scratchpad:
+    def __init__(self, max_lines: int = 8):
+        self.max_lines = max_lines
+        self._lines: List[str] = []
+
+    def add(self, line: str) -> None:
+        if len(self._lines) >= self.max_lines:
+            self._lines.pop(0)
+        self._lines.append(line.strip())
+
+    def render(self) -> str:
+        return "\n".join(self._lines)
+
+
+__all__ = ["Scratchpad"]

--- a/liquid_llm_vertex_pkg_stage1/stage1/tool_use/traces.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/tool_use/traces.py
@@ -1,0 +1,29 @@
+"""Trace parser for CALL/RESULT tool supervision."""
+
+import re
+from typing import Iterable
+
+from .registry import call_tool
+
+CALL_RE = re.compile(r'^CALL\s+(?P<tool>[\w_]+):"(?P<arg>.*)"$')
+
+
+def maybe_inject_tool_result(text: str) -> str:
+    lines = text.splitlines()
+    output_lines = []
+    for line in lines:
+        output_lines.append(line)
+        match = CALL_RE.match(line.strip())
+        if match:
+            tool = match.group("tool")
+            arg = match.group("arg")
+            result = call_tool(tool, arg)
+            output_lines.append(f"RESULT: {result}")
+    return "\n".join(output_lines)
+
+
+def inject_for_lines(lines: Iterable[str]) -> str:
+    return maybe_inject_tool_result("\n".join(lines))
+
+
+__all__ = ["maybe_inject_tool_result", "inject_for_lines"]

--- a/liquid_llm_vertex_pkg_stage1/stage1/train.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/train.py
@@ -1,0 +1,221 @@
+"""Training loop implementation."""
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, TYPE_CHECKING
+
+import torch
+from torch.cuda.amp import GradScaler
+from torch.optim import AdamW
+
+from . import gcs_io
+from .data import DataModule
+from .eval import run_eval
+from .losses import LossMixer, combined_loss
+from .utils import ThroughputMeter, cosine_with_warmup_schedule
+
+LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    import gcsfs
+
+
+@dataclass
+class TeacherProvider:
+    mode: str
+    logits_dir: str
+    teacher_model: Optional[torch.nn.Module] = None
+
+    def _teacher_device(self) -> torch.device:
+        if self.teacher_model is None:
+            return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        return next(self.teacher_model.parameters()).device
+
+    def get_logits(self, input_ids: torch.Tensor) -> torch.Tensor:
+        if self.mode == "online":
+            if self.teacher_model is None:
+                raise RuntimeError("Teacher model not loaded for online mode")
+            with torch.no_grad():
+                return self.teacher_model(input_ids=input_ids.to(self._teacher_device())).logits
+        import gcsfs
+
+        fs = gcsfs.GCSFileSystem()
+        batch_logits = []
+        for seq in input_ids:
+            key = hashlib.sha1(seq.cpu().numpy().tobytes()).hexdigest()
+            target_uri = f"{self.logits_dir.rstrip('/')}/{key}.pt"
+            local_path = Path("/tmp/teacher_cache") / f"{key}.pt"
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                fs.get(target_uri, str(local_path))
+                payload = torch.load(local_path, map_location="cpu")
+                batch_logits.append(payload["logits"])  # shape [seq, vocab]
+            except FileNotFoundError:
+                if self.teacher_model is None:
+                    raise FileNotFoundError(f"Missing teacher logits shard {target_uri}")
+                with torch.no_grad():
+                    logits = self.teacher_model(input_ids=seq.unsqueeze(0).to(self._teacher_device())).logits[0].cpu()
+                torch.save({"logits": logits}, local_path)
+                fs.put(str(local_path), target_uri)
+                batch_logits.append(logits)
+        return torch.stack(batch_logits, dim=0)
+
+
+@dataclass
+class TrainingConfig:
+    learning_rate: float
+    betas: tuple
+    weight_decay: float
+    warmup_steps: int
+    max_steps: int
+    eval_every: int
+    save_every: int
+    kd_temperature: float
+    kd_alpha_start: float
+    kd_alpha_end: float
+    kd_anneal_pct: float
+    keep_old_logit_l2: float
+    keep_old_logit_l2_fade_step: int
+    output_gcs_uri: str
+    run_id: str
+    precision: str = "bfloat16"
+
+
+def prepare_optimizer(model: torch.nn.Module, config: TrainingConfig) -> AdamW:
+    optimizer = AdamW(
+        model.parameters(),
+        lr=config.learning_rate,
+        betas=config.betas,
+        weight_decay=config.weight_decay,
+    )
+    return optimizer
+
+
+def train(
+    model: torch.nn.Module,
+    datamodule: DataModule,
+    device: torch.device,
+    teacher_provider: TeacherProvider,
+    config: TrainingConfig,
+    precision_dtype: torch.dtype,
+    log_path: Path,
+    tensorboard_dir: Optional[Path] = None,
+) -> None:
+    optimizer = prepare_optimizer(model, config)
+    scheduler = cosine_with_warmup_schedule(optimizer, config.warmup_steps, config.max_steps)
+    scaler = GradScaler(enabled=(precision_dtype == torch.float16))
+    mixer = LossMixer(
+        kd_alpha_start=config.kd_alpha_start,
+        kd_alpha_end=config.kd_alpha_end,
+        kd_anneal_pct=config.kd_anneal_pct,
+    )
+
+    tb_writer = None
+    if tensorboard_dir:
+        from torch.utils.tensorboard import SummaryWriter
+
+        tensorboard_dir.mkdir(parents=True, exist_ok=True)
+        tb_writer = SummaryWriter(log_dir=str(tensorboard_dir))
+
+    train_loader = iter(datamodule.train_dataloader())
+    throughput = ThroughputMeter()
+    best_perplexity = float("inf")
+    step = 0
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "w") as log_file:
+        while step < config.max_steps:
+            batch = next(train_loader)
+            input_ids = batch["input_ids"].to(device)
+            labels = batch["labels"].to(device)
+            attention_mask = batch.get("attention_mask")
+            if attention_mask is not None:
+                attention_mask = attention_mask.to(device)
+
+            teacher_logits = teacher_provider.get_logits(input_ids)
+            teacher_logits = teacher_logits.to(device)
+
+            optimizer.zero_grad(set_to_none=True)
+            start = time.time()
+            with torch.cuda.amp.autocast(dtype=precision_dtype, enabled=True):
+                outputs = model(input_ids=input_ids, attention_mask=attention_mask)
+                logits = outputs.logits
+                loss = combined_loss(
+                    logits,
+                    teacher_logits,
+                    labels,
+                    step=step,
+                    total_steps=config.max_steps,
+                    mixer=mixer,
+                    temperature=config.kd_temperature,
+                    baseline_logits=None,
+                    baseline_weight=config.keep_old_logit_l2,
+                    baseline_fade_step=config.keep_old_logit_l2_fade_step,
+                )
+            if scaler.is_enabled():
+                scaler.scale(loss).backward()
+                scaler.unscale_(optimizer)
+            else:
+                loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            if scaler.is_enabled():
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                optimizer.step()
+            scheduler.step()
+            duration = time.time() - start
+            throughput.update(input_ids.numel(), duration)
+
+            if step % 50 == 0:
+                log_line = json.dumps(
+                    {
+                        "step": step,
+                        "loss": float(loss.detach().cpu()),
+                        "lr": optimizer.param_groups[0]["lr"],
+                        "tokens_per_sec": throughput.tokens_per_second(),
+                    }
+                )
+                log_file.write(log_line + "\n")
+                log_file.flush()
+                LOGGER.info(log_line)
+                gcs_io.upload_logs_periodically(log_path, f"gs://liquid-llm-bucket-2/logs/stage1_console/{config.run_id}.log")
+                if tb_writer:
+                    tb_writer.add_scalar("train/loss", float(loss.detach().cpu()), step)
+                    tb_writer.add_scalar("train/lr", optimizer.param_groups[0]["lr"], step)
+
+            if (step + 1) % config.eval_every == 0:
+                metrics = run_eval(model, datamodule, device)
+                if tb_writer:
+                    for key, value in metrics.items():
+                        tb_writer.add_scalar(f"eval/{key}", value, step)
+                if metrics["perplexity"] < best_perplexity:
+                    best_perplexity = metrics["perplexity"]
+                    _save_checkpoint(model, config, suffix="best")
+
+            if (step + 1) % config.save_every == 0:
+                _save_checkpoint(model, config, suffix="last")
+
+            step += 1
+
+    if tb_writer:
+        tb_writer.close()
+
+
+def _save_checkpoint(model: torch.nn.Module, config: TrainingConfig, suffix: str) -> None:
+    local_path = Path("/tmp") / f"student_{suffix}.pt"
+    torch.save(model.state_dict(), local_path)
+    if suffix == "best":
+        filename = "_best.pt"
+    else:
+        filename = "last.pt"
+    target = f"{config.output_gcs_uri.rstrip('/')}/{config.run_id}/{filename}"
+    LOGGER.info("Uploading checkpoint to %s", target)
+    gcs_io.gcs_cp(str(local_path), target)
+
+
+__all__ = ["train", "TrainingConfig", "TeacherProvider"]

--- a/liquid_llm_vertex_pkg_stage1/stage1/utils.py
+++ b/liquid_llm_vertex_pkg_stage1/stage1/utils.py
@@ -1,0 +1,94 @@
+"""Utility helpers for Stage 1 training."""
+
+import argparse
+import dataclasses
+import logging
+import math
+import os
+import random
+import time
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Tuple
+
+import numpy as np
+import torch
+
+LOGGER = logging.getLogger(__name__)
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    LOGGER.info("Seed set to %d", seed)
+
+
+@dataclass
+class ThroughputMeter:
+    window: int = 50
+    times: Tuple[float, ...] = dataclasses.field(default_factory=tuple)
+
+    def update(self, n_tokens: int, duration_s: float) -> None:
+        entry = (time.time(), n_tokens, duration_s)
+        self.times = (self.times + (entry,))[-self.window :]
+
+    def tokens_per_second(self) -> float:
+        if not self.times:
+            return 0.0
+        total_tokens = sum(t[1] for t in self.times)
+        total_time = sum(t[2] for t in self.times)
+        return total_tokens / max(total_time, 1e-6)
+
+
+def cosine_with_warmup_schedule(optimizer: torch.optim.Optimizer, warmup_steps: int, total_steps: int, min_lr: float = 0.0):
+    def lr_lambda(step: int) -> float:
+        if step < warmup_steps:
+            return float(step + 1) / float(max(1, warmup_steps))
+        progress = (step - warmup_steps) / max(1, total_steps - warmup_steps)
+        return max(min_lr, 0.5 * (1.0 + math.cos(math.pi * progress)))
+
+    return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+
+
+def str2bool(v: str) -> bool:
+    if isinstance(v, bool):
+        return v
+    if v.lower() in {"yes", "true", "t", "1", "y"}:
+        return True
+    if v.lower() in {"no", "false", "f", "0", "n"}:
+        return False
+    raise argparse.ArgumentTypeError("Boolean value expected.")
+
+
+def parse_betas(betas: str) -> Tuple[float, float]:
+    parts = betas.split(",")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("Betas must be 'beta1,beta2'.")
+    return float(parts[0]), float(parts[1])
+
+
+def ensure_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def chunked(iterable: Iterable, n: int) -> Iterator[Tuple]:
+    chunk = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) == n:
+            yield tuple(chunk)
+            chunk = []
+    if chunk:
+        yield tuple(chunk)
+
+
+__all__ = [
+    "set_seed",
+    "ThroughputMeter",
+    "cosine_with_warmup_schedule",
+    "str2bool",
+    "parse_betas",
+    "ensure_dir",
+    "chunked",
+]

--- a/liquid_llm_vertex_pkg_stage1/tests/conftest.py
+++ b/liquid_llm_vertex_pkg_stage1/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/liquid_llm_vertex_pkg_stage1/tests/test_attention_backend.py
+++ b/liquid_llm_vertex_pkg_stage1/tests/test_attention_backend.py
@@ -1,0 +1,5 @@
+from stage1 import runtime_setup
+
+
+def test_attention_backend_fallback():
+    runtime_setup.configure_attention_backend(None)

--- a/liquid_llm_vertex_pkg_stage1/tests/test_kd_loss.py
+++ b/liquid_llm_vertex_pkg_stage1/tests/test_kd_loss.py
@@ -1,0 +1,12 @@
+import torch
+
+from stage1.losses import kd_loss
+
+
+def test_kd_temperature_scaling():
+    logits_s = torch.randn(2, 3)
+    logits_t = torch.randn(2, 3)
+    loss_t1 = kd_loss(logits_s, logits_t, temperature=1.0)
+    loss_t2 = kd_loss(logits_s, logits_t, temperature=2.0)
+    assert loss_t2 >= 0
+    assert loss_t1 >= 0

--- a/liquid_llm_vertex_pkg_stage1/tests/test_tool_pipeline.py
+++ b/liquid_llm_vertex_pkg_stage1/tests/test_tool_pipeline.py
@@ -1,0 +1,20 @@
+from stage1.tool_use.calculator import SafeCalculator
+from stage1.tool_use.scratchpad import Scratchpad
+from stage1.tool_use.traces import maybe_inject_tool_result
+
+
+def test_tool_pipeline():
+    calc = SafeCalculator()
+    result = calc.evaluate("sin(pi/2)")
+    assert abs(float(result) - 1.0) < 1e-6
+
+    scratch = Scratchpad(max_lines=2)
+    scratch.add("line1")
+    scratch.add("line2")
+    assert scratch.render() == "line1\nline2"
+    scratch.add("line3")
+    assert scratch.render() == "line2\nline3"
+
+    text = "CALL calculator:\"2+2\""
+    injected = maybe_inject_tool_result(text)
+    assert "RESULT:" in injected


### PR DESCRIPTION
## Summary
- add the `liquid_llm_vertex_pkg_stage1` Python package with setup metadata, runtime requirements, and README deployment guidance
- implement the Stage 1 training stack including runtime setup, model/teacher loading, data streaming, loss functions, training loop, evaluation utilities, and tool-use helpers
- provide supervised tool-use components and automated tests covering attention backend selection, KD loss numerics, and tool execution traces

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68eeccfb90a88321b6242ec4de4c82c3