### PR TITLE
Add streaming GCS preprocessing toolkit

### DIFF
--- a/vertex/package/sandbox/preprocess-toolkit/README.md
+++ b/vertex/package/sandbox/preprocess-toolkit/README.md
@@ -1,0 +1,43 @@
+# Preprocess Toolkit
+
+This toolkit provides dataset preprocessing pipelines that normalize diverse input
+formats into standardized JSONL shards ready for model training. Pipelines run in
+Vertex containers or on local Linux machines and stream data to minimize memory
+usage.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run an individual dataset by supplying the dataset name, input URI, and output
+shard directory. For example, to process WikiText-103:
+
+```bash
+python -m preprocess_toolkit.driver \
+  --job wikitext \
+  --in gs://liquid-llm-bucket-2/datasets/stage1/core/wikitext/wikitext-103-v1.zip \
+  --out gs://liquid-llm-bucket-2/datasets/stage1/core/wikitext/shards/ \
+  --max-records 20000 --manifest
+```
+
+Run all configured datasets from `config/datasets.yaml`:
+
+```bash
+python -m preprocess_toolkit.driver --job all --manifest
+```
+
+## Notes
+
+* All pipelines stream their inputs and write incremental shards to avoid high
+  memory usage. Large files are downloaded to the temporary working directory
+  and processed chunk-by-chunk.
+* GCS operations use `gcloud storage` with retries. If unavailable, the toolkit
+  falls back to `gcsfs` for object access.
+* To adjust dataset sampling weights or shard destinations, edit
+  `config/datasets.yaml` and rerun the manifest builder or pipeline driver.
+* The manifest builder prints manifest lines exactly as expected by downstream
+  consumers, making it easy to regenerate manifests after updates.

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/__init__.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/__init__.py
@@ -1,0 +1,11 @@
+"""Preprocess toolkit package."""
+
+from . import driver, manifest_builder, normalize, shard, io  # noqa: F401
+
+__all__ = [
+    "driver",
+    "manifest_builder",
+    "normalize",
+    "shard",
+    "io",
+]

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/config/datasets.yaml
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/config/datasets.yaml
@@ -1,0 +1,129 @@
+wikitext:
+  type: lm
+  in: gs://liquid-llm-bucket-2/datasets/stage1/core/wikitext/wikitext-103-v1.zip
+  out: gs://liquid-llm-bucket-2/datasets/stage1/core/wikitext/shards/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/core/wikitext/shards/*.jsonl","type":"lm","weight":1.0}
+
+wikipedia:
+  type: lm
+  in: gs://liquid-llm-bucket-2/datasets/stage1/core/wikipedia/enwiki-latest-pages-articles-multistream.xml.bz2
+  out: gs://liquid-llm-bucket-2/datasets/stage1/core/wikipedia/shards/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/core/wikipedia/shards/*.jsonl","type":"lm","weight":1.0}
+
+c4_train:
+  type: lm
+  in: gs://liquid-llm-bucket-2/datasets/stage1/core/c4/c4-train.00000-of-01024.json.gz
+  out: gs://liquid-llm-bucket-2/datasets/stage1/core/c4/shards/train/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/core/c4/c4-train.*.json.gz","type":"lm","weight":1.0}
+
+c4_validation:
+  type: lm
+  in: gs://liquid-llm-bucket-2/datasets/stage1/core/c4/c4-validation.00000-of-00008.json.gz
+  out: gs://liquid-llm-bucket-2/datasets/stage1/core/c4/shards/validation/
+  manifest: null
+
+fineweb_edu_10bt:
+  type: lm
+  in:
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/000_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/001_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/002_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/003_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/004_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/005_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/006_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/007_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/008_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/009_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/010_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/011_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/012_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/013_00000.parquet
+  out: gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/shards/10BT/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-10BT/*.parquet","type":"lm","weight":1.0}
+
+fineweb_edu_100bt:
+  type: lm
+  in:
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/000_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/000_00001.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/000_00002.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/000_00003.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/000_00004.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/000_00005.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/001_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/001_00001.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/002_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/003_00000.parquet
+  out: gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/shards/100BT/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-100BT/*.parquet","type":"lm","weight":0.35}
+
+fineweb_edu_350bt:
+  type: lm
+  in:
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00000.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00001.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00002.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00003.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00004.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00005.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00006.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00007.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00008.parquet
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/000_00009.parquet
+  out: gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/shards/350BT/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/core/fineweb-edu/sample-350BT/*.parquet","type":"lm","weight":0.25}
+
+dolma_v1_6_sample:
+  type: lm
+  in:
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0000.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0001.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0002.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0003.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0004.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0005.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0006.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0007.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0008.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0009.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0010.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0011.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0012.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0013.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0014.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0015.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0016.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0017.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0018.json.gz
+    - gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/v1_5r2_sample-0019.json.gz
+  out: gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/shards/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/core/dolma/v1_6_sample/*.json.gz","type":"lm","weight":0.5}
+
+gsm8k:
+  type: math_tool
+  in:
+    - gs://liquid-llm-bucket-2/datasets/stage1/math/gsm8k/train.jsonl
+    - gs://liquid-llm-bucket-2/datasets/stage1/math/gsm8k/test.jsonl
+  out: gs://liquid-llm-bucket-2/datasets/stage1/math/gsm8k/shards/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/math/gsm8k/*.jsonl","type":"math_tool","weight":0.5}
+
+svamp:
+  type: math_tool
+  in: gs://liquid-llm-bucket-2/datasets/stage1/math/svamp/SVAMP.json
+  out: gs://liquid-llm-bucket-2/datasets/stage1/math/svamp/shards/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/math/svamp/*.jsonl","type":"math_tool","weight":0.3}
+
+asdiv:
+  type: math_tool
+  in: gs://liquid-llm-bucket-2/datasets/stage1/math/asdiv/ASDiv.xml
+  out: gs://liquid-llm-bucket-2/datasets/stage1/math/asdiv/shards/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/math/asdiv/*.jsonl","type":"math_tool","weight":0.3}
+
+codesearchnet:
+  type: code
+  in:
+    - gs://liquid-llm-bucket-2/datasets/stage1/code/CodeSearchNet/python.zip
+    - gs://liquid-llm-bucket-2/datasets/stage1/code/CodeSearchNet/java.zip
+  out: gs://liquid-llm-bucket-2/datasets/stage1/code/codesearchnet/shards/
+  manifest: {"path":"gs://liquid-llm-bucket-2/datasets/stage1/code/codesearchnet/shards/*.jsonl","type":"code","weight":0.2}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/driver.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/driver.py
@@ -1,0 +1,232 @@
+"""Command line driver for dataset preprocessing pipelines."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+import sys
+from typing import Dict, Iterable, List, Tuple
+
+import yaml
+
+from . import io
+from .pipelines import (
+    asdiv,
+    c4,
+    codesearchnet,
+    dolma,
+    fineweb_edu,
+    gsm8k,
+    svamp,
+    wikipedia,
+    wikitext,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+CONFIG_MAP = {
+    "wikitext": ["wikitext"],
+    "wikipedia": ["wikipedia"],
+    "c4": ["c4_train", "c4_validation"],
+    "fineweb_edu": ["fineweb_edu_10bt", "fineweb_edu_100bt", "fineweb_edu_350bt"],
+    "dolma": ["dolma_v1_6_sample"],
+    "gsm8k": ["gsm8k"],
+    "svamp": ["svamp"],
+    "asdiv": ["asdiv"],
+    "codesearchnet": ["codesearchnet"],
+}
+
+PIPELINE_MODULES = {
+    "wikitext": wikitext,
+    "wikipedia": wikipedia,
+    "c4_train": c4,
+    "c4_validation": c4,
+    "fineweb_edu_10bt": fineweb_edu,
+    "fineweb_edu_100bt": fineweb_edu,
+    "fineweb_edu_350bt": fineweb_edu,
+    "dolma_v1_6_sample": dolma,
+    "gsm8k": gsm8k,
+    "svamp": svamp,
+    "asdiv": asdiv,
+    "codesearchnet": codesearchnet,
+}
+
+
+def load_datasets_config() -> Dict[str, dict]:
+    config_path = pathlib.Path(__file__).resolve().parent / "config" / "datasets.yaml"
+    with open(config_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _ensure_list(obj) -> List[str]:
+    if obj is None:
+        return []
+    if isinstance(obj, (list, tuple)):
+        return list(obj)
+    return [obj]
+
+
+def _prepare_inputs(inputs: Iterable[str], tmp_dir: str) -> List[Tuple[str, str]]:
+    local_inputs: List[Tuple[str, str]] = []
+    os.makedirs(tmp_dir, exist_ok=True)
+    for idx, uri in enumerate(inputs):
+        if uri.startswith("gs://"):
+            filename = os.path.basename(uri.rstrip("/")) or f"input-{idx}"
+            local_path = os.path.join(tmp_dir, filename)
+            LOGGER.info("Downloading %s to %s", uri, local_path)
+            io.gcs_to_local(uri, local_path)
+        else:
+            local_path = uri
+        local_inputs.append((uri, local_path))
+    return local_inputs
+
+
+def _upload_outputs(local_shard_dir: str, gcs_out: str) -> List[str]:
+    uploads: List[str] = []
+    for path in sorted(pathlib.Path(local_shard_dir).glob("*.jsonl")):
+        uploads.append(io.local_to_gcs(str(path), gcs_out))
+    return uploads
+
+
+def _resolve_manifest(entry: dict, override_type: str | None, override_weight: float | None) -> str | None:
+    manifest = entry.get("manifest")
+    if manifest is None:
+        return None
+    data = json.loads(manifest)
+    if override_type:
+        data["type"] = override_type
+    if override_weight is not None:
+        data["weight"] = override_weight
+    return json.dumps(data, separators=(",", ":"))
+
+
+def run_dataset(
+    dataset_key: str,
+    entry: dict,
+    *,
+    override_type: str | None,
+    override_weight: float | None,
+    in_override: str | None,
+    out_override: str | None,
+    max_records: int,
+    tmp_root: str,
+) -> dict:
+    module = PIPELINE_MODULES[dataset_key]
+    dataset_type = override_type or entry.get("type", "lm")
+    inputs = _ensure_list(in_override or entry.get("in"))
+    output_uri = out_override or entry.get("out")
+    if not output_uri:
+        raise ValueError(f"No output destination for dataset {dataset_key}")
+
+    dataset_tmp = os.path.join(tmp_root, dataset_key)
+    work_tmp = os.path.join(dataset_tmp, "work")
+    local_inputs = _prepare_inputs(inputs, os.path.join(dataset_tmp, "inputs"))
+    local_output_dir = os.path.join(dataset_tmp, "shards")
+    os.makedirs(work_tmp, exist_ok=True)
+
+    LOGGER.info("Running pipeline %s", dataset_key)
+    summary = module.run(
+        local_inputs,
+        local_output_dir,
+        dataset_type=dataset_type,
+        max_records=max_records,
+        work_dir=work_tmp,
+    )
+
+    uploads = _upload_outputs(local_output_dir, output_uri)
+    manifest_line = _resolve_manifest(entry, override_type, override_weight)
+
+    first_shard = os.path.basename(summary["shards"][0]) if summary["shards"] else "n/a"
+    last_shard = os.path.basename(summary["shards"][-1]) if summary["shards"] else "n/a"
+    LOGGER.info(
+        "Dataset %s processed %s records into %s shards (%s -> %s)",
+        dataset_key,
+        summary["records"],
+        len(summary["shards"]),
+        first_shard,
+        last_shard,
+    )
+
+    return {
+        "dataset": dataset_key,
+        "records": summary["records"],
+        "shards": summary["shards"],
+        "uploads": uploads,
+        "manifest": manifest_line,
+        "first_shard": first_shard,
+        "last_shard": last_shard,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Dataset preprocessing toolkit")
+    parser.add_argument(
+        "--job",
+        required=True,
+        choices=[
+            "wikitext",
+            "wikipedia",
+            "c4",
+            "fineweb_edu",
+            "dolma",
+            "gsm8k",
+            "svamp",
+            "asdiv",
+            "codesearchnet",
+            "all",
+        ],
+    )
+    parser.add_argument("--in", dest="input_path", help="Override input GCS URI", default=None)
+    parser.add_argument("--out", dest="output_path", help="Override output GCS directory", default=None)
+    parser.add_argument("--type", dest="sample_type", choices=["lm", "math_tool", "code"], default=None)
+    parser.add_argument("--max-records", dest="max_records", type=int, default=20000)
+    parser.add_argument("--manifest", action="store_true", help="Print manifest line(s)")
+    parser.add_argument("--weight", dest="weight", type=float, default=None)
+    parser.add_argument("--tmp", dest="tmp_dir", default="/tmp/prep")
+    parser.add_argument("--log-level", dest="log_level", default="INFO")
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    config = load_datasets_config()
+
+    if args.job == "all":
+        dataset_keys = list(config.keys())
+    else:
+        dataset_keys = CONFIG_MAP[args.job]
+
+    results = []
+    for key in dataset_keys:
+        entry = config[key]
+        in_override = args.input_path
+        out_override = args.output_path
+        if args.input_path and len(dataset_keys) > 1:
+            raise ValueError("--in override is ambiguous for multi-dataset jobs")
+        if args.output_path and len(dataset_keys) > 1:
+            raise ValueError("--out override is ambiguous for multi-dataset jobs")
+        result = run_dataset(
+            key,
+            entry,
+            override_type=args.sample_type,
+            override_weight=args.weight,
+            in_override=in_override,
+            out_override=out_override,
+            max_records=args.max_records,
+            tmp_root=args.tmp_dir,
+        )
+        results.append(result)
+        if args.manifest and result["manifest"]:
+            print(result["manifest"])
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/io.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/io.py
@@ -1,0 +1,112 @@
+"""I/O helpers for interacting with Google Cloud Storage."""
+
+from __future__ import annotations
+
+import logging
+import os
+import pathlib
+import subprocess
+import time
+from typing import Iterable, List, Optional
+
+try:
+    import gcsfs  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency in tests
+    gcsfs = None
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _split_gs_uri(uri: str) -> tuple[str, str]:
+    if not uri.startswith("gs://"):
+        raise ValueError(f"Not a GCS uri: {uri}")
+    parts = uri[5:].split("/", 1)
+    bucket = parts[0]
+    path = parts[1] if len(parts) == 2 else ""
+    return bucket, path
+
+
+def _run_gcloud(args: Iterable[str], retries: int = 3, delay: float = 1.0) -> subprocess.CompletedProcess:
+    cmd = ["gcloud", "storage", *args]
+    last_err: Optional[Exception] = None
+    for attempt in range(1, retries + 1):
+        try:
+            LOGGER.debug("Running gcloud command: %s", " ".join(cmd))
+            proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            return proc
+        except FileNotFoundError as exc:  # pragma: no cover - environment specific
+            raise
+        except subprocess.CalledProcessError as exc:
+            last_err = exc
+            LOGGER.warning("gcloud command failed (attempt %s/%s): %s", attempt, retries, exc)
+            time.sleep(delay * attempt)
+    if last_err:
+        raise last_err
+    raise RuntimeError("Unknown gcloud execution failure")
+
+
+def _ensure_gcsfs():
+    if gcsfs is None:
+        raise RuntimeError("gcsfs is required when gcloud is unavailable")
+    try:
+        retry_module = getattr(gcsfs, "retry", None)
+        if retry_module and hasattr(retry_module, "FilesystemInconsistency"):
+            return gcsfs.GCSFileSystem(retry_handler=retry_module.FilesystemInconsistency())
+    except Exception:  # pragma: no cover - fallback when retry is unsupported
+        pass
+    return gcsfs.GCSFileSystem()
+
+
+def gcs_to_local(uri: str, local_path: str) -> str:
+    """Download a GCS object to ``local_path``.
+
+    Uses ``gcloud storage cp`` when available. Falls back to ``gcsfs`` when
+    ``gcloud`` is missing or fails.
+    """
+
+    directory = os.path.dirname(local_path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    try:
+        _run_gcloud(["cp", uri, local_path])
+        return local_path
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        LOGGER.info("Falling back to gcsfs for download: %s", uri)
+    fs = _ensure_gcsfs()
+    bucket, path = _split_gs_uri(uri)
+    with fs.open(f"{bucket}/{path}", "rb") as src, open(local_path, "wb") as dst:
+        for chunk in iter(lambda: src.read(1024 * 1024), b""):
+            dst.write(chunk)
+    return local_path
+
+
+def local_to_gcs(local_path: str, uri: str) -> str:
+    """Upload ``local_path`` to the destination ``uri`` on GCS."""
+
+    if uri.endswith("/"):
+        uri = uri + pathlib.Path(local_path).name
+    try:
+        _run_gcloud(["cp", local_path, uri])
+        return uri
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        LOGGER.info("Falling back to gcsfs for upload: %s", uri)
+    fs = _ensure_gcsfs()
+    bucket, path = _split_gs_uri(uri)
+    with open(local_path, "rb") as src, fs.open(f"{bucket}/{path}", "wb") as dst:
+        for chunk in iter(lambda: src.read(1024 * 1024), b""):
+            dst.write(chunk)
+    return uri
+
+
+def list_gcs(glob_uri: str) -> List[str]:
+    """List objects matching ``glob_uri`` on GCS."""
+
+    try:
+        proc = _run_gcloud(["ls", glob_uri])
+        return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        LOGGER.info("Falling back to gcsfs for list: %s", glob_uri)
+    fs = _ensure_gcsfs()
+    bucket, path = _split_gs_uri(glob_uri)
+    matches = fs.glob(f"{bucket}/{path}")
+    return [f"gs://{match}" for match in matches]

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/manifest_builder.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/manifest_builder.py
@@ -1,0 +1,27 @@
+"""Utility to print manifest entries from the dataset configuration."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Dict
+
+import yaml
+
+
+def load_config() -> Dict[str, dict]:
+    config_path = pathlib.Path(__file__).resolve().parent / "config" / "datasets.yaml"
+    with open(config_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def main() -> None:
+    config = load_config()
+    for entry in config.values():
+        manifest = entry.get("manifest")
+        if manifest:
+            print(json.dumps(json.loads(manifest), separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/normalize.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/normalize.py
@@ -1,0 +1,51 @@
+"""Text normalization helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+WHITESPACE_RE = re.compile(r"[ \t\f\v]+")
+MULTI_NEWLINE_RE = re.compile(r"\n{3,}")
+
+
+def normalize_text(
+    text: Optional[str],
+    *,
+    min_length: int = 10,
+    language: Optional[str] = None,
+    collapse_whitespace: bool = True,
+) -> Optional[str]:
+    """Normalize ``text`` and return a cleaned string or ``None``.
+
+    Parameters
+    ----------
+    text:
+        The input text to normalize.
+    min_length:
+        Minimum length of the normalized text. Shorter samples are discarded.
+    language:
+        Optional language hint for future extensions. Currently unused but kept
+        for API compatibility.
+    """
+
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        text = str(text)
+    text = text.replace("\r", "\n")
+    text = CONTROL_RE.sub(" ", text)
+    if collapse_whitespace:
+        text = WHITESPACE_RE.sub(" ", text)
+        text = MULTI_NEWLINE_RE.sub("\n\n", text)
+        text = re.sub(r" *\n *", "\n", text)
+    text = text.strip()
+    if not text or len(text) < min_length:
+        return None
+    # Ensure round-trip through UTF-8 to drop invalid bytes.
+    try:
+        text = text.encode("utf-8", "ignore").decode("utf-8", "ignore")
+    except Exception:
+        return None
+    return text

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/__init__.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/__init__.py
@@ -1,0 +1,25 @@
+"""Dataset pipeline modules."""
+
+from . import (
+    asdiv,
+    c4,
+    codesearchnet,
+    dolma,
+    fineweb_edu,
+    gsm8k,
+    svamp,
+    wikipedia,
+    wikitext,
+)
+
+__all__ = [
+    "asdiv",
+    "c4",
+    "codesearchnet",
+    "dolma",
+    "fineweb_edu",
+    "gsm8k",
+    "svamp",
+    "wikipedia",
+    "wikitext",
+]

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/asdiv.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/asdiv.py
@@ -1,0 +1,53 @@
+"""Pipeline for ASDiv XML dataset."""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+from typing import List, Tuple
+
+from .. import normalize, shard
+
+
+def run(
+    local_inputs: List[Tuple[str, str]],
+    output_dir: str,
+    *,
+    dataset_type: str,
+    max_records: int,
+    work_dir: str,
+) -> dict:
+    del work_dir
+    os.makedirs(output_dir, exist_ok=True)
+    record_index = 0
+    with shard.ShardWriter(output_dir, dataset_type, max_records=max_records) as writer:
+        for source_uri, path in local_inputs:
+            tree = ET.parse(path)
+            root = tree.getroot()
+            for problem in root.iter():
+                if problem.tag.lower() not in {"problem", "item"}:
+                    continue
+                body = (
+                    problem.findtext("Body")
+                    or problem.findtext("body")
+                    or problem.findtext("Description")
+                    or ""
+                )
+                question = (
+                    problem.findtext("Question")
+                    or problem.findtext("question")
+                    or problem.findtext("Problem")
+                    or ""
+                )
+                answer = (
+                    problem.findtext("Answer")
+                    or problem.findtext("answer")
+                    or ""
+                )
+                text = f"{body}\n\nQ: {question}\nA:"
+                text = normalize.normalize_text(text, min_length=5)
+                if text:
+                    sample_id = shard.compute_sample_id(source_uri, record_index, text)
+                    writer.write(sample_id, text, dataset_type)
+                record_index += 1
+    return {"records": writer.total_records, "shards": writer.shard_paths}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/c4.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/c4.py
@@ -1,0 +1,44 @@
+"""Pipeline for C4 dataset JSONL shards."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+from typing import List, Tuple
+
+from .. import normalize, shard
+
+
+def _iter_records(path: str):
+    with gzip.open(path, "rt", encoding="utf-8", errors="ignore") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def run(
+    local_inputs: List[Tuple[str, str]],
+    output_dir: str,
+    *,
+    dataset_type: str,
+    max_records: int,
+    work_dir: str,
+) -> dict:
+    del work_dir
+    os.makedirs(output_dir, exist_ok=True)
+    record_index = 0
+    with shard.ShardWriter(output_dir, dataset_type, max_records=max_records) as writer:
+        for source_uri, path in local_inputs:
+            for record in _iter_records(path):
+                text = normalize.normalize_text(record.get("text"))
+                if text:
+                    sample_id = shard.compute_sample_id(source_uri, record_index, text)
+                    writer.write(sample_id, text, dataset_type)
+                record_index += 1
+    return {"records": writer.total_records, "shards": writer.shard_paths}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/codesearchnet.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/codesearchnet.py
@@ -1,0 +1,112 @@
+"""Pipeline for CodeSearchNet archives."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import zipfile
+from typing import List, Tuple
+
+from .. import normalize, shard
+
+CODE_EXTENSIONS = {".py", ".java", ".js", ".go", ".php", ".rb"}
+JSON_FIELDS = ["code", "func_code", "original_string", "content"]
+
+
+def _handle_jsonl(
+    zf: zipfile.ZipFile,
+    info: zipfile.ZipInfo,
+    *,
+    source_uri: str,
+    writer: shard.ShardWriter,
+    start_index: int,
+    dataset_type: str,
+) -> int:
+    record_index = start_index
+    with zf.open(info) as fh:
+        text_io = io.TextIOWrapper(fh, encoding="utf-8", errors="ignore")
+        for line in text_io:
+            line = line.strip()
+            if not line:
+                continue
+            record_index += 1
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            value = None
+            for field in JSON_FIELDS:
+                if field in obj and obj[field]:
+                    value = obj[field]
+                    break
+            if value is None:
+                continue
+            text = normalize.normalize_text(value, min_length=5, collapse_whitespace=False)
+            if not text:
+                continue
+            sample_id = shard.compute_sample_id(source_uri, record_index, text)
+            writer.write(sample_id, text, dataset_type)
+    return record_index
+
+
+def _handle_code_file(
+    zf: zipfile.ZipFile,
+    info: zipfile.ZipInfo,
+    *,
+    source_uri: str,
+    writer: shard.ShardWriter,
+    start_index: int,
+    dataset_type: str,
+) -> int:
+    record_index = start_index + 1
+    with zf.open(info) as fh:
+        content = fh.read().decode("utf-8", "ignore")
+    text = normalize.normalize_text(content, min_length=5, collapse_whitespace=False)
+    if text:
+        sample_id = shard.compute_sample_id(source_uri, record_index, text)
+        writer.write(sample_id, text, dataset_type)
+    return record_index
+
+
+def run(
+    local_inputs: List[Tuple[str, str]],
+    output_dir: str,
+    *,
+    dataset_type: str,
+    max_records: int,
+    work_dir: str,
+) -> dict:
+    del work_dir
+    os.makedirs(output_dir, exist_ok=True)
+    record_index = 0
+    with shard.ShardWriter(output_dir, dataset_type, max_records=max_records) as writer:
+        for source_uri, path in local_inputs:
+            with zipfile.ZipFile(path) as zf:
+                jsonl_files = [info for info in zf.infolist() if info.filename.lower().endswith(".jsonl")]
+                if jsonl_files:
+                    for info in jsonl_files:
+                        record_index = _handle_jsonl(
+                            zf,
+                            info,
+                            source_uri=source_uri,
+                            writer=writer,
+                            start_index=record_index,
+                            dataset_type=dataset_type,
+                        )
+                else:
+                    for info in zf.infolist():
+                        if info.is_dir():
+                            continue
+                        _, ext = os.path.splitext(info.filename)
+                        if ext.lower() not in CODE_EXTENSIONS:
+                            continue
+                        record_index = _handle_code_file(
+                            zf,
+                            info,
+                            source_uri=source_uri,
+                            writer=writer,
+                            start_index=record_index,
+                            dataset_type=dataset_type,
+                        )
+    return {"records": writer.total_records, "shards": writer.shard_paths}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/dolma.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/dolma.py
@@ -1,0 +1,44 @@
+"""Pipeline for Dolma JSONL samples."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+from typing import List, Tuple
+
+from .. import normalize, shard
+
+
+def _iter_records(path: str):
+    with gzip.open(path, "rt", encoding="utf-8", errors="ignore") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def run(
+    local_inputs: List[Tuple[str, str]],
+    output_dir: str,
+    *,
+    dataset_type: str,
+    max_records: int,
+    work_dir: str,
+) -> dict:
+    del work_dir
+    os.makedirs(output_dir, exist_ok=True)
+    record_index = 0
+    with shard.ShardWriter(output_dir, dataset_type, max_records=max_records) as writer:
+        for source_uri, path in local_inputs:
+            for record in _iter_records(path):
+                text = normalize.normalize_text(record.get("text"))
+                if text:
+                    sample_id = shard.compute_sample_id(source_uri, record_index, text)
+                    writer.write(sample_id, text, dataset_type)
+                record_index += 1
+    return {"records": writer.total_records, "shards": writer.shard_paths}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/fineweb_edu.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/fineweb_edu.py
@@ -1,0 +1,46 @@
+"""Pipeline for FineWeb-Edu parquet samples."""
+
+from __future__ import annotations
+
+import os
+from typing import List, Tuple
+
+import pyarrow.parquet as pq
+
+from .. import normalize, shard
+
+
+def _detect_text_column(pf: pq.ParquetFile) -> str:
+    schema = pf.schema
+    for candidate in ("text", "content"):
+        if schema.get_field_index(candidate) != -1:
+            return candidate
+    raise ValueError("No text/content column found in parquet file")
+
+
+def run(
+    local_inputs: List[Tuple[str, str]],
+    output_dir: str,
+    *,
+    dataset_type: str,
+    max_records: int,
+    work_dir: str,
+) -> dict:
+    del work_dir
+    os.makedirs(output_dir, exist_ok=True)
+    record_index = 0
+    with shard.ShardWriter(output_dir, dataset_type, max_records=max_records) as writer:
+        for source_uri, path in local_inputs:
+            pf = pq.ParquetFile(path)
+            column = _detect_text_column(pf)
+            for batch in pf.iter_batches(batch_size=512):
+                col_index = batch.schema.get_field_index(column)
+                col = batch.column(col_index)
+                texts = col.to_pylist()
+                for value in texts:
+                    text = normalize.normalize_text(value)
+                    if text:
+                        sample_id = shard.compute_sample_id(source_uri, record_index, text)
+                        writer.write(sample_id, text, dataset_type)
+                    record_index += 1
+    return {"records": writer.total_records, "shards": writer.shard_paths}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/gsm8k.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/gsm8k.py
@@ -1,0 +1,46 @@
+"""Pipeline for GSM8K math dataset."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Tuple
+
+from .. import normalize, shard
+
+
+def run(
+    local_inputs: List[Tuple[str, str]],
+    output_dir: str,
+    *,
+    dataset_type: str,
+    max_records: int,
+    work_dir: str,
+) -> dict:
+    del work_dir
+    os.makedirs(output_dir, exist_ok=True)
+    record_index = 0
+    with shard.ShardWriter(output_dir, dataset_type, max_records=max_records) as writer:
+        for source_uri, path in local_inputs:
+            with open(path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        record_index += 1
+                        continue
+                    question = obj.get("question") or obj.get("question_text")
+                    answer = obj.get("answer") or obj.get("answer_text")
+                    pieces = [question or ""]
+                    if answer:
+                        pieces.append("")
+                        pieces.append(f"Answer: {answer}")
+                    text = normalize.normalize_text("\n".join(pieces), min_length=5)
+                    if text:
+                        sample_id = shard.compute_sample_id(source_uri, record_index, text)
+                        writer.write(sample_id, text, dataset_type)
+                    record_index += 1
+    return {"records": writer.total_records, "shards": writer.shard_paths}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/svamp.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/svamp.py
@@ -1,0 +1,37 @@
+"""Pipeline for SVAMP math dataset."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Tuple
+
+from .. import normalize, shard
+
+
+def run(
+    local_inputs: List[Tuple[str, str]],
+    output_dir: str,
+    *,
+    dataset_type: str,
+    max_records: int,
+    work_dir: str,
+) -> dict:
+    del work_dir
+    os.makedirs(output_dir, exist_ok=True)
+    record_index = 0
+    with shard.ShardWriter(output_dir, dataset_type, max_records=max_records) as writer:
+        for source_uri, path in local_inputs:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            for item in data:
+                body = item.get("Body") or ""
+                question = item.get("Question") or item.get("question") or ""
+                answer = item.get("Answer") or item.get("answer") or ""
+                text = f"{body}\n\nQ: {question}\nA:"
+                text = normalize.normalize_text(text, min_length=5)
+                if text:
+                    sample_id = shard.compute_sample_id(source_uri, record_index, text)
+                    writer.write(sample_id, text, dataset_type)
+                record_index += 1
+    return {"records": writer.total_records, "shards": writer.shard_paths}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/wikipedia.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/wikipedia.py
@@ -1,0 +1,53 @@
+"""Pipeline for Wikipedia dumps using WikiExtractor."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+from .. import normalize, shard
+
+
+def _extract_dump(xml_path: str, output_dir: str) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    cmd = [
+        sys.executable,
+        "-m",
+        "wikiextractor.WikiExtractor",
+        xml_path,
+        "--processes",
+        "1",
+        "-q",
+        "-o",
+        output_dir,
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def run(
+    local_inputs: List[Tuple[str, str]],
+    output_dir: str,
+    *,
+    dataset_type: str,
+    max_records: int,
+    work_dir: str,
+) -> dict:
+    os.makedirs(output_dir, exist_ok=True)
+    record_index = 0
+    with shard.ShardWriter(output_dir, dataset_type, max_records=max_records) as writer:
+        for source_uri, path in local_inputs:
+            extract_dir = os.path.join(work_dir, f"extract_{record_index}")
+            _extract_dump(path, extract_dir)
+            for text_file in Path(extract_dir).rglob("*.txt"):
+                content = text_file.read_text(encoding="utf-8", errors="ignore")
+                text = normalize.normalize_text(content)
+                if not text:
+                    record_index += 1
+                    continue
+                sample_id = shard.compute_sample_id(source_uri, record_index, text)
+                writer.write(sample_id, text, dataset_type)
+                record_index += 1
+    return {"records": writer.total_records, "shards": writer.shard_paths}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/wikitext.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/pipelines/wikitext.py
@@ -1,0 +1,54 @@
+"""Pipeline for WikiText datasets."""
+
+from __future__ import annotations
+
+import io
+import os
+import zipfile
+from typing import Iterable, List, Tuple
+
+from .. import normalize, shard
+
+
+def _iter_documents(zf: zipfile.ZipFile, name: str) -> Iterable[str]:
+    with zf.open(name) as fh:
+        text_io = io.TextIOWrapper(fh, encoding="utf-8", errors="ignore")
+        buffer: List[str] = []
+        for line in text_io:
+            stripped = line.rstrip("\n")
+            if stripped.strip() == "":
+                if buffer:
+                    yield "\n".join(buffer)
+                    buffer = []
+            else:
+                buffer.append(stripped)
+        if buffer:
+            yield "\n".join(buffer)
+
+
+def run(
+    local_inputs: List[Tuple[str, str]],
+    output_dir: str,
+    *,
+    dataset_type: str,
+    max_records: int,
+    work_dir: str,
+) -> dict:
+    del work_dir  # Unused but kept for signature compatibility.
+    os.makedirs(output_dir, exist_ok=True)
+    record_index = 0
+    with shard.ShardWriter(output_dir, dataset_type, max_records=max_records) as writer:
+        for source_uri, path in local_inputs:
+            with zipfile.ZipFile(path) as zf:
+                for name in zf.namelist():
+                    if name.endswith("/"):
+                        continue
+                    for doc in _iter_documents(zf, name):
+                        text = normalize.normalize_text(doc)
+                        if not text:
+                            record_index += 1
+                            continue
+                        sample_id = shard.compute_sample_id(source_uri, record_index, text)
+                        writer.write(sample_id, text, dataset_type)
+                        record_index += 1
+    return {"records": writer.total_records, "shards": writer.shard_paths}

--- a/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/shard.py
+++ b/vertex/package/sandbox/preprocess-toolkit/preprocess_toolkit/shard.py
@@ -1,0 +1,110 @@
+"""Shard writing utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import IO, Optional
+
+
+def compute_sample_id(source_uri: str, index: int, normalized_text: str) -> str:
+    """Compute a deterministic sample identifier."""
+
+    sha = hashlib.sha1()
+    snippet = normalized_text[:200]
+    sha.update(source_uri.encode("utf-8"))
+    sha.update(str(index).encode("utf-8"))
+    sha.update(snippet.encode("utf-8"))
+    return sha.hexdigest()
+
+
+@dataclass
+class ShardStats:
+    records: int = 0
+    shards: int = 0
+
+
+class ShardWriter:
+    """Incrementally writes normalized JSONL shards with deduplication."""
+
+    def __init__(
+        self,
+        output_dir: str,
+        sample_type: str,
+        max_records: int = 20000,
+        encoding: str = "utf-8",
+    ) -> None:
+        self.output_dir = output_dir
+        self.sample_type = sample_type
+        self.max_records = max_records
+        self.encoding = encoding
+        self._shard_index = 0
+        self._records_in_shard = 0
+        self._total_records = 0
+        self._fh: Optional[IO[str]] = None
+        self._dedup_hashes: set[str] = set()
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    def _open_new_shard(self) -> None:
+        if self._fh:
+            self._fh.close()
+        filename = f"part-{self._shard_index:05d}.jsonl"
+        path = os.path.join(self.output_dir, filename)
+        self._fh = open(path, "w", encoding=self.encoding)
+        self._records_in_shard = 0
+        self._dedup_hashes = set()
+        self._shard_index += 1
+
+    @property
+    def shard_paths(self) -> list[str]:
+        return [
+            os.path.join(self.output_dir, name)
+            for name in sorted(os.listdir(self.output_dir))
+            if name.endswith(".jsonl")
+        ]
+
+    def write(self, sample_id: str, text: str, sample_type: Optional[str] = None) -> bool:
+        """Write a normalized sample to the current shard.
+
+        Returns ``True`` if the sample was written, ``False`` if it was deduplicated.
+        """
+
+        if not text:
+            return False
+        hashed_text = hashlib.sha1(text.encode("utf-8")).hexdigest()
+        if hashed_text in self._dedup_hashes:
+            return False
+        if self._fh is None or self._records_in_shard >= self.max_records:
+            self._open_new_shard()
+        payload = {
+            "sample_id": sample_id,
+            "type": sample_type or self.sample_type,
+            "text": text,
+        }
+        assert self._fh is not None
+        self._fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        self._records_in_shard += 1
+        self._total_records += 1
+        self._dedup_hashes.add(hashed_text)
+        return True
+
+    def close(self) -> None:
+        if self._fh:
+            self._fh.close()
+            self._fh = None
+
+    def __enter__(self) -> "ShardWriter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    @property
+    def total_records(self) -> int:
+        return self._total_records
+
+    @property
+    def num_shards(self) -> int:
+        return max(self._shard_index if self._records_in_shard else self._shard_index - 1, 0)

--- a/vertex/package/sandbox/preprocess-toolkit/pyproject.toml
+++ b/vertex/package/sandbox/preprocess-toolkit/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "preprocess-toolkit"
+version = "0.1.0"
+description = "Streaming preprocessing toolkit for Liquid LLM datasets"
+authors = [{name = "Liquid LLM"}]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["preprocess_toolkit"]

--- a/vertex/package/sandbox/preprocess-toolkit/requirements.txt
+++ b/vertex/package/sandbox/preprocess-toolkit/requirements.txt
@@ -1,0 +1,10 @@
+ujson
+orjson
+tqdm
+gcsfs
+pyarrow
+fastparquet
+wikiextractor
+mwparserfromhell
+lxml
+pandas

--- a/vertex/package/sandbox/preprocess-toolkit/tests/conftest.py
+++ b/vertex/package/sandbox/preprocess-toolkit/tests/conftest.py
@@ -1,0 +1,6 @@
+import pathlib
+import sys
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/vertex/package/sandbox/preprocess-toolkit/tests/test_gcs_io.py
+++ b/vertex/package/sandbox/preprocess-toolkit/tests/test_gcs_io.py
@@ -1,0 +1,72 @@
+import io
+import os
+
+import pytest
+
+from preprocess_toolkit import io as gcs_io
+
+
+class FakeFile(io.BytesIO):
+    def __init__(self, storage, path, mode, initial=b""):
+        self.storage = storage
+        self.path = path
+        self.mode = mode
+        super().__init__(initial)
+
+    def close(self):
+        if "w" in self.mode:
+            self.storage[self.path] = self.getvalue()
+        super().close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False
+
+
+class FakeFS:
+    def __init__(self):
+        self.storage = {}
+
+    def open(self, path, mode):
+        if "r" in mode:
+            data = self.storage.get(path, b"")
+            return FakeFile(self.storage, path, mode, data)
+        return FakeFile(self.storage, path, mode)
+
+    def glob(self, pattern):
+        # simple glob that returns all stored paths
+        return list(self.storage.keys())
+
+
+@pytest.fixture(autouse=True)
+def patch_gcloud(monkeypatch):
+    monkeypatch.setattr(gcs_io, "_run_gcloud", lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()))
+    fake_fs = FakeFS()
+    fake_fs.storage["bucket/object.txt"] = b"hello"
+    monkeypatch.setattr(gcs_io, "_ensure_gcsfs", lambda: fake_fs)
+    return fake_fs
+
+
+def test_gcs_download_and_upload(tmp_path, patch_gcloud):
+    local_file = tmp_path / "download.txt"
+    gcs_io.gcs_to_local("gs://bucket/object.txt", str(local_file))
+    assert local_file.read_text() == "hello"
+
+    upload_file = tmp_path / "upload.txt"
+    upload_file.write_text("goodbye")
+    gcs_io.local_to_gcs(str(upload_file), "gs://bucket/new_object.txt")
+    assert patch_gcloud.storage["bucket/new_object.txt"] == b"goodbye"
+
+
+def test_list_gcs(tmp_path, patch_gcloud):
+    patch_gcloud.storage["bucket/another.txt"] = b"x"
+    file_path = tmp_path / "extra.txt"
+    file_path.write_text("data")
+    gcs_io.local_to_gcs(str(file_path), "gs://bucket/new_object.txt")
+    items = gcs_io.list_gcs("gs://bucket/*")
+    assert "gs://bucket/object.txt" in items
+    assert "gs://bucket/new_object.txt" in items
+    assert "gs://bucket/another.txt" in items

--- a/vertex/package/sandbox/preprocess-toolkit/tests/test_min_pipelines.py
+++ b/vertex/package/sandbox/preprocess-toolkit/tests/test_min_pipelines.py
@@ -1,0 +1,46 @@
+import gzip
+import json
+from pathlib import Path
+
+from preprocess_toolkit.pipelines import c4, dolma, gsm8k
+
+
+def _read_output(shard_paths):
+    lines = []
+    for path in shard_paths:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                lines.append(json.loads(line))
+    return lines
+
+
+def test_c4_pipeline(tmp_path):
+    input_path = tmp_path / "c4.json.gz"
+    with gzip.open(input_path, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps({"text": "This is a sample document for testing."}) + "\n")
+        fh.write(json.dumps({"text": "Another example text for C4."}) + "\n")
+    summary = c4.run([("gs://bucket/c4", str(input_path))], str(tmp_path / "out"), dataset_type="lm", max_records=1, work_dir=str(tmp_path / "work"))
+    assert summary["records"] >= 2
+    outputs = _read_output(summary["shards"])
+    assert all(sample["text"] for sample in outputs)
+
+
+def test_dolma_pipeline(tmp_path):
+    input_path = tmp_path / "dolma.json.gz"
+    with gzip.open(input_path, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps({"text": "Dolma text example."}) + "\n")
+    summary = dolma.run([("gs://bucket/dolma", str(input_path))], str(tmp_path / "out_d"), dataset_type="lm", max_records=10, work_dir=str(tmp_path / "work_d"))
+    assert summary["records"] >= 1
+    outputs = _read_output(summary["shards"])
+    assert outputs[0]["type"] == "lm"
+
+
+def test_gsm8k_pipeline(tmp_path):
+    input_path = tmp_path / "gsm8k.jsonl"
+    with open(input_path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"question": "What is 1+1?", "answer": "2"}) + "\n")
+    summary = gsm8k.run([("gs://bucket/gsm8k", str(input_path))], str(tmp_path / "out_g"), dataset_type="math_tool", max_records=10, work_dir=str(tmp_path / "work_g"))
+    assert summary["records"] >= 1
+    outputs = _read_output(summary["shards"])
+    assert outputs[0]["type"] == "math_tool"
+    assert "Answer:" in outputs[0]["text"]

--- a/vertex/package/sandbox/preprocess-toolkit/tests/test_shard.py
+++ b/vertex/package/sandbox/preprocess-toolkit/tests/test_shard.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+from preprocess_toolkit import shard
+
+
+def test_shard_rotation_and_schema(tmp_path):
+    writer = shard.ShardWriter(tmp_path, "lm", max_records=2)
+    texts = ["Sample one text", "Sample two text", "Sample three text"]
+    for idx, text in enumerate(texts):
+        sample_id = shard.compute_sample_id("gs://bucket/file", idx, text)
+        writer.write(sample_id, text)
+    writer.close()
+
+    shard_files = sorted(Path(tmp_path).glob("*.jsonl"))
+    assert len(shard_files) == 2
+    payloads = []
+    for path in shard_files:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                payload = json.loads(line)
+                assert set(payload) == {"sample_id", "type", "text"}
+                payloads.append(payload)
+    assert len(payloads) == 3
+    assert payloads[0]["sample_id"] == shard.compute_sample_id("gs://bucket/file", 0, texts[0])
+
+
+def test_dedup_within_shard(tmp_path):
+    writer = shard.ShardWriter(tmp_path, "lm", max_records=10)
+    text = "Duplicate text"
+    sample_id = shard.compute_sample_id("gs://bucket/file", 0, text)
+    assert writer.write(sample_id, text) is True
+    sample_id2 = shard.compute_sample_id("gs://bucket/file", 1, text)
+    assert writer.write(sample_id2, text) is False
+    writer.close()


### PR DESCRIPTION
## Summary
- add a reusable preprocessing toolkit with dataset configuration, CLI driver, and manifest builder for Vertex workflows
- implement streaming dataset pipelines with normalization, shard writers, and GCS IO fallbacks plus accompanying tests

## Testing
- pytest vertex/package/sandbox/preprocess-toolkit/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68f02d6111788321aa121c65fe3a3f5e