### PR TITLE
Enable per-step KD, SDPA attention, and immediate checkpoint uploads

### DIFF
--- a/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/eval.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/eval.py
@@ -2,30 +2,92 @@
 from __future__ import annotations
 
 import math
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import torch
 from torch.utils.data import DataLoader
 
 from .losses import ce_loss
+from .tool_use import traces
 from .utils import configure_logging
 
 logger = configure_logging()
 
 
-def evaluate_perplexity(model: torch.nn.Module, dataloader: DataLoader) -> float:
+def run_validation(model: torch.nn.Module, dataloader: DataLoader, max_batches: int = 16) -> Dict[str, Optional[float]]:
     model.eval()
-    losses = []
+    losses: List[float] = []
+    tool_preds: List[str] = []
+    tool_targets: List[str] = []
+    tokenizer = getattr(getattr(dataloader, "dataset", None), "tokenizer", None)
+    processed_batches = 0
+    max_tool_samples = 16
     with torch.inference_mode():
         for batch in dataloader:
+            if processed_batches >= max_batches:
+                break
+            processed_batches += 1
             input_ids = batch["input_ids"].to(model.lm_head.weight.device)
-            logits = model(input_ids)
-            loss = ce_loss(logits[:, :-1], input_ids[:, 1:])
+            student_inputs = input_ids[:, :-1]
+            logits = model(student_inputs)
+            loss = ce_loss(logits, input_ids[:, 1:])
             losses.append(loss.item())
+            if tokenizer is None:
+                continue
+            types = batch.get("type")
+            if types is None:
+                continue
+            sample_types = types
+            if isinstance(sample_types, torch.Tensor):
+                sample_types = [t.item() for t in sample_types]
+            tool_count = 0
+            for idx, sample_type in enumerate(sample_types):
+                if sample_type != "math_tool" or tool_count >= max_tool_samples:
+                    continue
+                text = _decode_sample(batch, idx, tokenizer)
+                if not text:
+                    continue
+                actual, expected = _extract_tool_results(text)
+                if actual and expected and len(actual) == len(expected):
+                    tool_preds.extend(actual)
+                    tool_targets.extend(expected)
+                    tool_count += 1
     model.train()
-    if not losses:
-        return float("inf")
-    return math.exp(sum(losses) / len(losses))
+    metrics: Dict[str, Optional[float]] = {"perplexity": float("inf"), "tool_em": None}
+    if losses:
+        metrics["perplexity"] = math.exp(sum(losses) / len(losses))
+    if tool_preds and tool_targets:
+        metrics["tool_em"] = compute_tool_accuracy(tool_preds, tool_targets)
+    return metrics
+
+
+def _decode_sample(batch: Dict[str, torch.Tensor], idx: int, tokenizer) -> str:
+    input_ids = batch["input_ids"][idx]
+    attention_mask = batch.get("attention_mask")
+    if attention_mask is not None:
+        mask = attention_mask[idx]
+        if isinstance(mask, torch.Tensor):
+            length = int(mask.sum().item())
+            if length > 0:
+                input_ids = input_ids[:length]
+    try:
+        return tokenizer.decode(input_ids.tolist(), skip_special_tokens=True)
+    except Exception:
+        return ""
+
+
+def _extract_tool_results(text: str) -> Tuple[List[str], List[str]]:
+    actual: List[str] = []
+    for line in text.splitlines():
+        if line.strip().startswith("RESULT:"):
+            actual.append(line.split("RESULT:", 1)[1].strip())
+    stripped = "\n".join(line for line in text.splitlines() if not line.strip().startswith("RESULT:"))
+    reinjected = traces.maybe_inject_tool_result(stripped)
+    expected: List[str] = []
+    for line in reinjected.splitlines():
+        if line.strip().startswith("RESULT:"):
+            expected.append(line.split("RESULT:", 1)[1].strip())
+    return actual, expected
 
 
 def compute_tool_accuracy(preds: Iterable[str], targets: Iterable[str]) -> float:

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/losses.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/losses.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 
 
 def ce_loss(student_logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-    return F.cross_entropy(student_logits.view(-1, student_logits.size(-1)), labels.view(-1))
+    return F.cross_entropy(student_logits.reshape(-1, student_logits.size(-1)), labels.reshape(-1))
 
 
 def kd_loss(

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/teacher.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/teacher.py
@@ -34,9 +34,11 @@ class TeacherWrapper:
         self.model.eval()
         for param in self.model.parameters():
             param.requires_grad = False
+        self.device = next(self.model.parameters()).device
 
     @torch.inference_mode()
     def logits(self, input_ids: torch.Tensor) -> torch.Tensor:
+        input_ids = input_ids.to(self.device)
         outputs = self.model(input_ids=input_ids)
         return outputs.logits
 

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/train.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/train.py
@@ -1,6 +1,7 @@
 """Training loop implementation for Stage-1 KD."""
 from __future__ import annotations
 
+import json
 import os
 import shutil
 from pathlib import Path
@@ -11,7 +12,7 @@ from torch.optim import AdamW
 from torch.utils.data import DataLoader
 
 from . import losses
-from .eval import evaluate_perplexity
+from .eval import run_validation
 from .gcs_io import ensure_local_dir, local_to_gcs
 from .runtime_setup import enable_flash_attn_if_available
 from .utils import AnnealingSchedule, CosineLRSchedule, RunMetadata, configure_logging, json_log
@@ -28,6 +29,7 @@ class Trainer:
         device: torch.device,
         output_dir: str,
         output_gcs_uri: Optional[str],
+        run_id: str,
         lr: float,
         betas: tuple[float, float],
         weight_decay: float,
@@ -39,6 +41,11 @@ class Trainer:
         logit_l2_gamma_schedule: AnnealingSchedule,
         logit_reference: Optional[torch.Tensor] = None,
         precision: str = "bfloat16",
+        teacher: Optional[object] = None,
+        teacher_mode: str = "online",
+        teacher_logits_dir: Optional[str] = None,
+        eval_every: int = 1000,
+        save_every: int = 2000,
     ) -> None:
         self.model = model.to(device)
         self.train_loader = train_loader
@@ -46,6 +53,7 @@ class Trainer:
         self.device = device
         self.output_dir = ensure_local_dir(output_dir)
         self.output_gcs_uri = output_gcs_uri
+        self.run_id = run_id
         self.optimizer = AdamW(self.model.parameters(), lr=lr, betas=betas, weight_decay=weight_decay)
         self.scheduler = CosineLRSchedule(base_lr=lr, warmup_steps=warmup_steps, total_steps=max_steps)
         self.max_steps = max_steps
@@ -54,7 +62,7 @@ class Trainer:
         self.ce_beta_schedule = ce_beta_schedule
         self.logit_l2_gamma_schedule = logit_l2_gamma_schedule
         self.logit_reference = logit_reference
-        self.scaler = torch.cuda.amp.GradScaler(enabled=(precision == "fp16"))
+        self.scaler = torch.cuda.amp.GradScaler(enabled=(precision == "fp16" and torch.cuda.is_available()))
         self.precision = precision
         enable_flash_attn_if_available()
         if precision == "bfloat16" and torch.cuda.is_available():
@@ -63,8 +71,13 @@ class Trainer:
             self.amp_dtype = torch.float16
         else:
             self.amp_dtype = torch.float32
-        if hasattr(self.model, "gradient_checkpointing_enable"):
-            self.model.gradient_checkpointing_enable()
+        self.teacher = teacher
+        self.teacher_mode = teacher_mode
+        self.teacher_logits_dir = teacher_logits_dir
+        self.eval_every = eval_every
+        self.save_every = save_every
+        self._run_uri = f"{self.output_gcs_uri.rstrip('/')}/{self.run_id}" if self.output_gcs_uri else None
+        self._metrics_path = Path(self.output_dir) / "val_metrics.jsonl"
         self._provenance_synced = False
 
     def _save_checkpoint(self, name: str, step: int, val_ppl: float, losses_dict: Dict[str, float]) -> None:
@@ -76,17 +89,42 @@ class Trainer:
             "step": step,
         }
         torch.save(state, path)
+        if self._run_uri:
+            dest = f"{self._run_uri}/{name}"
+            local_to_gcs(str(path), dest)
         metadata = RunMetadata(step=step, val_ppl=val_ppl, losses=losses_dict, frozen_blocks=("block_0", "block_1"))
-        with (Path(self.output_dir) / "run_meta.json").open("w", encoding="utf-8") as f:
+        run_meta_path = Path(self.output_dir) / "run_meta.json"
+        with run_meta_path.open("w", encoding="utf-8") as f:
             f.write(metadata.to_json())
+        if self._run_uri:
+            local_to_gcs(str(run_meta_path), f"{self._run_uri}/run_meta.json")
         logger.info("Saved checkpoint %s", path)
 
     def _maybe_eval(self, step: int) -> float:
         if self.val_loader is None:
             return float("inf")
-        ppl = evaluate_perplexity(self.model, self.val_loader)
-        logger.info("Validation perplexity at step %d: %.4f", step, ppl)
-        return ppl
+        metrics = run_validation(self.model, self.val_loader)
+        metrics_payload = {"step": step, **metrics}
+        logger.info("Validation metrics at step %d: %s", step, json.dumps(metrics))
+        self._write_validation_metrics(metrics_payload)
+        return float(metrics.get("perplexity", float("inf")))
+
+    def _write_validation_metrics(self, payload: Dict[str, object]) -> None:
+        self._metrics_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._metrics_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+        if self._run_uri:
+            local_to_gcs(str(self._metrics_path), f"{self._run_uri}/val_metrics.jsonl")
+
+    def _compute_teacher_logits(self, input_ids: torch.Tensor, batch: Dict[str, torch.Tensor]) -> Optional[torch.Tensor]:
+        teacher_logits = batch.get("teacher_logits")
+        if teacher_logits is not None:
+            return teacher_logits.to(self.device)
+        if self.teacher is not None:
+            with torch.inference_mode():
+                logits = self.teacher.logits(input_ids)
+            return logits.to(self.device)
+        return None
 
     def train(self) -> None:
         best_ppl = float("inf")
@@ -105,16 +143,11 @@ class Trainer:
             autocast_ctx = torch.autocast(device_type=self.device.type, dtype=self.amp_dtype) if use_autocast else torch.cuda.amp.autocast(enabled=False)
             with autocast_ctx:
                 logits = self.model(student_inputs)
-                logits = logits[:, :-1]
-                teacher_logits = batch.get("teacher_logits")
-                if teacher_logits is not None:
-                    teacher_logits = teacher_logits.to(self.device)
+                teacher_logits = self._compute_teacher_logits(input_ids, batch)
                 ce = losses.ce_loss(logits, labels)
-                kd = (
-                    losses.kd_loss(logits, teacher_logits, self.kd_temperature)
-                    if teacher_logits is not None
-                    else torch.tensor(0.0, device=self.device)
-                )
+                kd = logits.new_zeros(())
+                if teacher_logits is not None:
+                    kd = losses.kd_loss(logits, teacher_logits[:, :-1, :], self.kd_temperature)
                 l2 = losses.logit_l2(logits, self.logit_reference)
                 alpha = self.kd_alpha_schedule.value(step, self.max_steps)
                 beta = self.ce_beta_schedule.value(step, self.max_steps)
@@ -144,16 +177,16 @@ class Trainer:
                 "lr": lr,
             }
             json_log(logger, metrics)
-            if step % 1000 == 0 and self.val_loader is not None:
+            if self.eval_every and self.val_loader is not None and step % self.eval_every == 0:
                 ppl = self._maybe_eval(step)
                 if ppl < best_ppl:
                     best_ppl = ppl
                     self._save_checkpoint("best.pt", step, ppl, metrics)
-            if step % 2000 == 0:
+            if self.save_every and step % self.save_every == 0:
                 self._save_checkpoint("last.pt", step, best_ppl, metrics)
             step += 1
-        if self.output_gcs_uri:
-            local_to_gcs(self.output_dir, self.output_gcs_uri)
+        if self._run_uri:
+            local_to_gcs(self.output_dir, self._run_uri)
 
     def _ensure_provenance_artifacts(self) -> None:
         if self._provenance_synced:

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_checkpoint_upload.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_checkpoint_upload.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from stage1.train import Trainer
+from stage1.utils import AnnealingSchedule
+
+
+class _TinyModel(torch.nn.Module):
+    def __init__(self, vocab_size: int = 8) -> None:
+        super().__init__()
+        self.embed = torch.nn.Embedding(vocab_size, 4)
+        self.ln = torch.nn.LayerNorm(4)
+        self.lm_head = torch.nn.Linear(4, vocab_size)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        hidden = self.embed(input_ids)
+        hidden = self.ln(hidden)
+        return self.lm_head(hidden)
+
+
+def test_checkpoint_uploads_immediately(tmp_path, monkeypatch):
+    dataset = TensorDataset(torch.randint(0, 8, (1, 5)))
+
+    def collate(batch):
+        return {"input_ids": torch.stack([item[0] for item in batch])}
+
+    loader = DataLoader(dataset, batch_size=1, collate_fn=collate)
+    model = _TinyModel()
+    trainer = Trainer(
+        model=model,
+        train_loader=loader,
+        val_loader=None,
+        device=torch.device("cpu"),
+        output_dir=str(tmp_path),
+        output_gcs_uri="gs://bucket/path",
+        run_id="run123",
+        lr=1e-3,
+        betas=(0.9, 0.95),
+        weight_decay=0.0,
+        warmup_steps=0,
+        max_steps=1,
+        kd_temperature=2.0,
+        kd_alpha_schedule=AnnealingSchedule(0.7, 0.4, 0.3),
+        ce_beta_schedule=AnnealingSchedule(0.3, 0.6, 0.3),
+        logit_l2_gamma_schedule=AnnealingSchedule(0.0, 0.0, 1.0),
+        logit_reference=None,
+        precision="fp32",
+        teacher=None,
+        teacher_mode="precompute",
+        teacher_logits_dir=None,
+        eval_every=0,
+        save_every=0,
+    )
+    monkeypatch.setenv("STAGE1_DATA_PROVENANCE_DIR", str(tmp_path))
+    with mock.patch("stage1.train.local_to_gcs") as upload_mock:
+        trainer._save_checkpoint("last.pt", 0, 1.0, {"loss_total": 0.0})
+        destinations = [call.args[1] for call in upload_mock.call_args_list]
+        assert f"gs://bucket/path/run123/last.pt" in destinations
+        assert f"gs://bucket/path/run123/run_meta.json" in destinations

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_kd_online_step.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_kd_online_step.py
@@ -1,0 +1,77 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from stage1.train import Trainer
+from stage1.utils import AnnealingSchedule
+
+
+class _ToyModel(torch.nn.Module):
+    def __init__(self, vocab_size: int = 8, seq_len: int = 4) -> None:
+        super().__init__()
+        self.embed = torch.nn.Embedding(vocab_size, 16)
+        self.ln = torch.nn.LayerNorm(16)
+        self.lm_head = torch.nn.Linear(16, vocab_size)
+        self.seq_len = seq_len
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        hidden = self.embed(input_ids)
+        hidden = self.ln(hidden)
+        return self.lm_head(hidden)
+
+
+class _Teacher:
+    def logits(self, input_ids: torch.Tensor) -> torch.Tensor:
+        batch, seq = input_ids.shape
+        vocab = 8
+        torch.manual_seed(0)
+        return torch.randn(batch, seq, vocab)
+
+
+def test_trainer_computes_online_kd(tmp_path):
+    torch.manual_seed(0)
+    dataset = TensorDataset(torch.randint(0, 8, (2, 5), dtype=torch.long))
+
+    def collate(batch):
+        input_ids = torch.stack([item[0] for item in batch])
+        return {"input_ids": input_ids}
+
+    loader = DataLoader(dataset, batch_size=2, collate_fn=collate)
+    model = _ToyModel()
+    trainer = Trainer(
+        model=model,
+        train_loader=loader,
+        val_loader=None,
+        device=torch.device("cpu"),
+        output_dir=str(tmp_path),
+        output_gcs_uri=None,
+        run_id="test",
+        lr=1e-3,
+        betas=(0.9, 0.95),
+        weight_decay=0.0,
+        warmup_steps=0,
+        max_steps=1,
+        kd_temperature=2.0,
+        kd_alpha_schedule=AnnealingSchedule(0.7, 0.4, 0.3),
+        ce_beta_schedule=AnnealingSchedule(0.3, 0.6, 0.3),
+        logit_l2_gamma_schedule=AnnealingSchedule(0.0, 0.0, 1.0),
+        logit_reference=None,
+        precision="fp32",
+        teacher=_Teacher(),
+        teacher_mode="online",
+        teacher_logits_dir=None,
+        eval_every=0,
+        save_every=0,
+    )
+    def fake_kd(student_logits, teacher_logits, temperature):
+        assert torch.isfinite(teacher_logits).all()
+        return (student_logits - teacher_logits.detach()).pow(2).mean()
+
+    with mock.patch("stage1.train.losses.kd_loss", side_effect=fake_kd) as kd_mock:
+        trainer.train()
+        assert kd_mock.called

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_sdp_attention.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_sdp_attention.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from stage1.model_init import Attention, StudentConfig
+
+
+def test_attention_uses_sdpa():
+    config = StudentConfig(vocab_size=32, hidden_size=16, n_heads=4, n_layers=2, intermediate_size=64, sequence_length=8)
+    layer = Attention(config)
+    x = torch.randn(2, 8, 16)
+    fake_out = torch.zeros(2, config.n_heads, 8, 4)
+    with mock.patch("stage1.model_init.F.scaled_dot_product_attention", return_value=fake_out) as sdpa_mock:
+        out = layer(x)
+    assert sdpa_mock.called
+    assert out.shape == (2, 8, 16)


### PR DESCRIPTION
## Summary
- wire online teacher inference into the CLI and trainer, add gradient checkpointing controls, and log startup data/KD context
- ingest precomputed logits when requested, switch attention to PyTorch SDPA, and upload checkpoints plus metadata immediately
- extend validation to report perplexity/tool metrics and add targeted unit tests for KD, SDPA attention, and checkpoint uploads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f04161e4648321b60bed52fed183b5