### PR TITLE
feat: polish Stage-1 Vertex trainer for reliability and observability

### DIFF
--- a/vertex/package/liquid_llm_vertex_pkg_stage1/README.md
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/README.md
@@ -19,6 +19,55 @@ To run in online teacher mode or with larger per-device batches, simply change t
 
 FlashAttention is installed at runtime from `gs://liquid-llm-bucket-2/FlashAttention/flash_attn-2.8.3+cu12torch2.4cxx11abiTRUE-cp310-cp310-linux_x86_64.whl`. The CLI automatically performs the download and install before training.
 
+## Dry run sanity check
+
+The package supports a lightweight dry run to validate data bootstrap, checkpointing, and evaluation without requiring a GPU. Run the following command on a CPU VM or your workstation:
+
+```bash
+python -m stage1.cli \
+  --dry-run=true \
+  --limit-batches=2 \
+  --metrics-interval=1 \
+  --prepare-data=skip \
+  --dataset-manifest=/path/to/local/manifest.jsonl \
+  --teacher-mode=precompute \
+  --teacher-logits-dir=/path/to/logits
+```
+
+The dry run builds two batches, performs a single optimizer step, runs one evaluation pass, and exits cleanly after saving `last.pt` plus emitting a few metric lines.
+
+## Knowledge distillation modes
+
+* **`--teacher-mode=online`** loads the Hugging Face teacher model at startup. The CLI prints the teacher vocab size and keeps the teacher under `torch.inference_mode()` for every batch. Use this when a GPU and HF token are available; KD losses are computed on the fly.
+* **`--teacher-mode=precompute`** expects `.pt` or `.npy` logits per sample in `--teacher-logits-dir`. The data loader validates shapes (`[seq, vocab]`), pads/truncates when necessary, and surfaces a `teacher_status` flag per batch. If >10% of batches in an epoch are missing logits, the trainer logs a prominent warning.
+
+## Metrics and observability
+
+Training metrics stream to `<run_dir>/metrics.jsonl` and are mirrored to GCS after every append. Each record includes:
+
+* `global_step`, `train_loss`, `ce_loss`, `kd_loss`, `logit_l2`
+* `lr`, `tokens_per_sec`, `examples_per_sec`, `grad_norm`, `gpu_mem_alloc_MB`
+* `val_ppl` when validation runs
+
+During the first ~2k steps on an L4 you should expect `tokens_per_sec` to stabilise after the warmup and `grad_norm` to stay finite (typically <10). Validation perplexity is logged whenever `--eval-every` divides the current step.
+
+The startup banner also captures seed, precision, SDPA status, FlashAttention wheel installation status, and data bootstrap summaries including per-dataset shard counts and auto-generated sample IDs.
+
+## Reliability and recovery
+
+The trainer guards against common failure modes:
+
+* **NaN/Inf detection** – the first non-finite loss or gradient skips the update and logs a warning; a consecutive occurrence triggers a `crash_dump.pt` containing model/optimizer state and batch shapes.
+* **AMP overflow** – if `GradScaler` detects overflow, the optimizer step is skipped, the scale is backed off, and the same batches are retried.
+* **CUDA OOM** – the current `grad_accum_steps` is halved (down to 1) and the offending step is retried. A second OOM writes a crash dump and raises with a clear message.
+* **Signals** – SIGTERM/SIGINT triggers a graceful shutdown that saves `last.pt`, flushes `metrics.jsonl`, uploads both, and exits with status 0.
+
+Crash dumps, checkpoints (`best.pt`, `last.pt`), `run_meta.json`, and `frozen_mask.json` are uploaded immediately after creation with a post-upload integrity check (`gcloud storage ls`).
+
+## Resuming training
+
+To resume from the latest checkpoint, point `--resume_gcs_uri` at the desired artifact (typically `last.pt`). The CLI also writes `args_snapshot.json` with the original argument set and provenance metadata (`HF_TOKEN_PRESENT`, `GOOGLE_CLOUD_PROJECT`, git commit) to aid reproducibility.
+
 ## Logs and checkpoints
 
 Console logs stream to Vertex automatically. The trainer emits JSON lines with metrics. Checkpoints and metadata are saved locally under `/tmp/vertex_run/` and mirrored to the configured GCS output directory. TensorBoard summaries can be synced by providing `--tb-gcs-uri`.

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/teacher.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/teacher.py
@@ -35,6 +35,12 @@ class TeacherWrapper:
         for param in self.model.parameters():
             param.requires_grad = False
         self.device = next(self.model.parameters()).device
+        logger.info(
+            "Teacher ready | vocab_size=%d | device=%s | dtype=%s",
+            len(self.tokenizer),
+            self.device,
+            config.dtype,
+        )
 
     @torch.inference_mode()
     def logits(self, input_ids: torch.Tensor) -> torch.Tensor:

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/train.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/train.py
@@ -2,10 +2,15 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import shutil
+import signal
+import time
+from collections import deque
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Iterable, Iterator, Optional
 
 import torch
 from torch.optim import AdamW
@@ -15,12 +20,66 @@ from . import losses
 from .eval import run_validation
 from .gcs_io import ensure_local_dir, local_to_gcs
 from .runtime_setup import enable_flash_attn_if_available
-from .utils import AnnealingSchedule, CosineLRSchedule, RunMetadata, configure_logging, json_log
+from .utils import (
+    AnnealingSchedule,
+    CosineLRSchedule,
+    RunMetadata,
+    configure_logging,
+    json_log,
+)
 
 logger = configure_logging()
 
 
+class MetricsStream:
+    """Append-only metrics writer that mirrors to GCS."""
+
+    def __init__(self, path: Path, run_uri: Optional[str]) -> None:
+        self.path = path
+        self.run_uri = run_uri.rstrip("/") if run_uri else None
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, payload: Dict[str, object]) -> None:
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+        self.flush()
+
+    def flush(self) -> None:
+        if self.run_uri and self.path.exists():
+            local_to_gcs(str(self.path), f"{self.run_uri}/metrics.jsonl")
+
+
+class SignalHandler:
+    """Simple RAII helper that installs signal handlers."""
+
+    def __init__(self, trainer: "Trainer") -> None:
+        self.trainer = trainer
+        self._orig_handlers: Dict[int, object] = {}
+
+    def __enter__(self) -> "SignalHandler":
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            self._orig_handlers[sig] = signal.getsignal(sig)
+            signal.signal(sig, self.trainer.handle_interrupt)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        for sig, handler in self._orig_handlers.items():
+            if handler is not None:
+                signal.signal(sig, handler)
+
+
+@dataclass
+class StepResult:
+    success: bool
+    metrics: Optional[Dict[str, float]]
+    tokens: int
+    examples: int
+    grad_norm: float
+
+
 class Trainer:
+    """Main training orchestrator."""
+
     def __init__(
         self,
         model: torch.nn.Module,
@@ -46,13 +105,18 @@ class Trainer:
         teacher_logits_dir: Optional[str] = None,
         eval_every: int = 1000,
         save_every: int = 2000,
+        grad_accum_steps: int = 1,
+        metrics_interval: int = 100,
+        limit_batches: int = 0,
+        early_stop_ppl: float = 0.0,
+        dry_run: bool = False,
     ) -> None:
         self.model = model.to(device)
         self.train_loader = train_loader
         self.val_loader = val_loader
         self.device = device
         self.output_dir = ensure_local_dir(output_dir)
-        self.output_gcs_uri = output_gcs_uri
+        self.output_gcs_uri = output_gcs_uri.rstrip("/") if output_gcs_uri else None
         self.run_id = run_id
         self.optimizer = AdamW(self.model.parameters(), lr=lr, betas=betas, weight_decay=weight_decay)
         self.scheduler = CosineLRSchedule(base_lr=lr, warmup_steps=warmup_steps, total_steps=max_steps)
@@ -62,23 +126,82 @@ class Trainer:
         self.ce_beta_schedule = ce_beta_schedule
         self.logit_l2_gamma_schedule = logit_l2_gamma_schedule
         self.logit_reference = logit_reference
-        self.scaler = torch.cuda.amp.GradScaler(enabled=(precision == "fp16" and torch.cuda.is_available()))
-        self.precision = precision
-        enable_flash_attn_if_available()
+        enable_flash_attn_if_available(log=False)
         if precision == "bfloat16" and torch.cuda.is_available():
             self.amp_dtype = torch.bfloat16
         elif precision == "fp16":
             self.amp_dtype = torch.float16
         else:
             self.amp_dtype = torch.float32
+        self.scaler = torch.cuda.amp.GradScaler(enabled=(precision == "fp16" and torch.cuda.is_available()))
         self.teacher = teacher
         self.teacher_mode = teacher_mode
         self.teacher_logits_dir = teacher_logits_dir
         self.eval_every = eval_every
         self.save_every = save_every
-        self._run_uri = f"{self.output_gcs_uri.rstrip('/')}/{self.run_id}" if self.output_gcs_uri else None
-        self._metrics_path = Path(self.output_dir) / "val_metrics.jsonl"
+        self.grad_accum_steps = max(1, grad_accum_steps)
+        self.current_grad_accum_steps = self.grad_accum_steps
+        self.metrics_interval = max(1, metrics_interval)
+        self.limit_batches = limit_batches
+        self.early_stop_ppl = max(0.0, early_stop_ppl)
+        self.dry_run = dry_run
+        self._run_uri = f"{self.output_gcs_uri}/{self.run_id}" if self.output_gcs_uri else None
+        self._metrics_stream = MetricsStream(Path(self.output_dir) / "metrics.jsonl", self._run_uri)
+        self._val_metrics_path = Path(self.output_dir) / "val_metrics.jsonl"
         self._provenance_synced = False
+        self._global_step = 0
+        self._best_ppl = float("inf")
+        self._last_metrics: Optional[Dict[str, float]] = None
+        self._consecutive_non_finite = 0
+        self._oom_retry_active = False
+        self._last_batch_shapes: Dict[str, Iterable[int]] = {}
+        self._batch_iterator = self._infinite_batches()
+        self._retry_batches: deque[Dict[str, torch.Tensor]] = deque()
+
+    @property
+    def global_step(self) -> int:
+        return self._global_step
+
+    def _infinite_batches(self) -> Iterator[Dict[str, torch.Tensor]]:
+        dataset = getattr(self.train_loader, "dataset", None)
+        if hasattr(dataset, "begin_epoch"):
+            dataset.begin_epoch()
+        data_iter = iter(self.train_loader)
+        batches_in_epoch = 0
+        while True:
+            try:
+                batch = next(data_iter)
+            except StopIteration:
+                self._on_epoch_end(dataset)
+                data_iter = iter(self.train_loader)
+                batches_in_epoch = 0
+                continue
+            batches_in_epoch += 1
+            if self.limit_batches and batches_in_epoch > self.limit_batches:
+                self._on_epoch_end(dataset)
+                data_iter = iter(self.train_loader)
+                batches_in_epoch = 0
+                continue
+            yield batch
+
+    def _on_epoch_end(self, dataset: Optional[object]) -> None:
+        if dataset and hasattr(dataset, "epoch_teacher_stats"):
+            total, missing = dataset.epoch_teacher_stats()
+            if total:
+                ratio = missing / float(total)
+                if ratio > 0.1:
+                    logger.warning(
+                        "KD logits missing for %.2f%% of samples this epoch", ratio * 100.0
+                    )
+        if dataset and hasattr(dataset, "begin_epoch"):
+            dataset.begin_epoch()
+
+    def handle_interrupt(self, signum, frame) -> None:  # pragma: no cover - signal handler
+        logger.warning("Received signal %s; saving last checkpoint before exit", signum)
+        metrics = self._last_metrics or {}
+        self._save_checkpoint("last.pt", self.global_step, self._best_ppl, metrics)
+        self._metrics_stream.flush()
+        raise SystemExit(0)
 
     def _save_checkpoint(self, name: str, step: int, val_ppl: float, losses_dict: Dict[str, float]) -> None:
         self._ensure_provenance_artifacts()
@@ -90,103 +213,22 @@ class Trainer:
         }
         torch.save(state, path)
         if self._run_uri:
-            dest = f"{self._run_uri}/{name}"
-            local_to_gcs(str(path), dest)
+            local_to_gcs(str(path), f"{self._run_uri}/{name}")
         metadata = RunMetadata(step=step, val_ppl=val_ppl, losses=losses_dict, frozen_blocks=("block_0", "block_1"))
         run_meta_path = Path(self.output_dir) / "run_meta.json"
         with run_meta_path.open("w", encoding="utf-8") as f:
             f.write(metadata.to_json())
         if self._run_uri:
             local_to_gcs(str(run_meta_path), f"{self._run_uri}/run_meta.json")
+            self._upload_frozen_mask()
         logger.info("Saved checkpoint %s", path)
 
-    def _maybe_eval(self, step: int) -> float:
-        if self.val_loader is None:
-            return float("inf")
-        metrics = run_validation(self.model, self.val_loader)
-        metrics_payload = {"step": step, **metrics}
-        logger.info("Validation metrics at step %d: %s", step, json.dumps(metrics))
-        self._write_validation_metrics(metrics_payload)
-        return float(metrics.get("perplexity", float("inf")))
-
-    def _write_validation_metrics(self, payload: Dict[str, object]) -> None:
-        self._metrics_path.parent.mkdir(parents=True, exist_ok=True)
-        with self._metrics_path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, sort_keys=True) + "\n")
-        if self._run_uri:
-            local_to_gcs(str(self._metrics_path), f"{self._run_uri}/val_metrics.jsonl")
-
-    def _compute_teacher_logits(self, input_ids: torch.Tensor, batch: Dict[str, torch.Tensor]) -> Optional[torch.Tensor]:
-        teacher_logits = batch.get("teacher_logits")
-        if teacher_logits is not None:
-            return teacher_logits.to(self.device)
-        if self.teacher is not None:
-            with torch.inference_mode():
-                logits = self.teacher.logits(input_ids)
-            return logits.to(self.device)
-        return None
-
-    def train(self) -> None:
-        best_ppl = float("inf")
-        step = 0
-        data_iter = iter(self.train_loader)
-        use_autocast = self.device.type != "cpu"
-        while step < self.max_steps:
-            try:
-                batch = next(data_iter)
-            except StopIteration:
-                data_iter = iter(self.train_loader)
-                batch = next(data_iter)
-            input_ids = batch["input_ids"].to(self.device)
-            labels = input_ids[:, 1:].contiguous()
-            student_inputs = input_ids[:, :-1]
-            autocast_ctx = torch.autocast(device_type=self.device.type, dtype=self.amp_dtype) if use_autocast else torch.cuda.amp.autocast(enabled=False)
-            with autocast_ctx:
-                logits = self.model(student_inputs)
-                teacher_logits = self._compute_teacher_logits(input_ids, batch)
-                ce = losses.ce_loss(logits, labels)
-                kd = logits.new_zeros(())
-                if teacher_logits is not None:
-                    kd = losses.kd_loss(logits, teacher_logits[:, :-1, :], self.kd_temperature)
-                l2 = losses.logit_l2(logits, self.logit_reference)
-                alpha = self.kd_alpha_schedule.value(step, self.max_steps)
-                beta = self.ce_beta_schedule.value(step, self.max_steps)
-                gamma = self.logit_l2_gamma_schedule.value(step, self.max_steps)
-                total_loss = alpha * kd + beta * ce + gamma * l2
-            self.optimizer.zero_grad()
-            if self.scaler.is_enabled():
-                self.scaler.scale(total_loss).backward()
-                self.scaler.unscale_(self.optimizer)
-            else:
-                total_loss.backward()
-            torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
-            if self.scaler.is_enabled():
-                self.scaler.step(self.optimizer)
-                self.scaler.update()
-            else:
-                self.optimizer.step()
-            lr = self.scheduler.value(step)
-            for param_group in self.optimizer.param_groups:
-                param_group["lr"] = lr
-            metrics = {
-                "step": step,
-                "loss_total": float(total_loss.detach().cpu()),
-                "loss_ce": float(ce.detach().cpu()),
-                "loss_kd": float(kd.detach().cpu()),
-                "loss_l2": float(l2.detach().cpu()),
-                "lr": lr,
-            }
-            json_log(logger, metrics)
-            if self.eval_every and self.val_loader is not None and step % self.eval_every == 0:
-                ppl = self._maybe_eval(step)
-                if ppl < best_ppl:
-                    best_ppl = ppl
-                    self._save_checkpoint("best.pt", step, ppl, metrics)
-            if self.save_every and step % self.save_every == 0:
-                self._save_checkpoint("last.pt", step, best_ppl, metrics)
-            step += 1
-        if self._run_uri:
-            local_to_gcs(self.output_dir, self._run_uri)
+    def _upload_frozen_mask(self) -> None:
+        if not self._run_uri:
+            return
+        mask_path = Path(self.output_dir) / "frozen_mask.json"
+        if mask_path.exists():
+            local_to_gcs(str(mask_path), f"{self._run_uri}/frozen_mask.json")
 
     def _ensure_provenance_artifacts(self) -> None:
         if self._provenance_synced:
@@ -200,3 +242,238 @@ class Trainer:
             if src.exists() and not dst.exists():
                 shutil.copy(src, dst)
         self._provenance_synced = True
+
+    def _write_validation_metrics(self, payload: Dict[str, object]) -> None:
+        self._val_metrics_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._val_metrics_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+        if self._run_uri:
+            local_to_gcs(str(self._val_metrics_path), f"{self._run_uri}/val_metrics.jsonl")
+
+    def _compute_teacher_logits(
+        self, batch: Dict[str, torch.Tensor], input_ids: torch.Tensor
+    ) -> Optional[torch.Tensor]:
+        teacher_logits = batch.get("teacher_logits")
+        if teacher_logits is not None:
+            return teacher_logits.to(self.device)
+        if self.teacher is None:
+            return None
+        with torch.inference_mode():
+            logits = self.teacher.logits(input_ids)
+        return logits.to(self.device)
+
+    def _dump_crash(self, reason: str) -> None:
+        path = Path(self.output_dir) / "crash_dump.pt"
+        payload = {
+            "reason": reason,
+            "step": self.global_step,
+            "model": self.model.state_dict(),
+            "optimizer": self.optimizer.state_dict(),
+            "batch_shapes": self._last_batch_shapes,
+        }
+        torch.save(payload, path)
+        if self._run_uri:
+            local_to_gcs(str(path), f"{self._run_uri}/crash_dump.pt")
+
+    def _handle_non_finite(self, what: str) -> StepResult:
+        self._consecutive_non_finite += 1
+        if self._consecutive_non_finite == 1:
+            logger.warning("Detected non-finite %s; skipping update", what)
+            self.optimizer.zero_grad(set_to_none=True)
+            if self.scaler.is_enabled():
+                self.scaler.update()
+            return StepResult(False, None, 0, 0, 0.0)
+        self._dump_crash(f"non_finite_{what}")
+        raise RuntimeError(f"Encountered consecutive non-finite {what}; aborting")
+
+    def _handle_oom(self, err: RuntimeError) -> StepResult:
+        if "out of memory" not in str(err).lower() or not torch.cuda.is_available():
+            raise err
+        torch.cuda.empty_cache()
+        if not self._oom_retry_active:
+            new_accum = max(1, self.current_grad_accum_steps // 2)
+            if new_accum == self.current_grad_accum_steps and new_accum == 1:
+                self._dump_crash("cuda_oom")
+                raise RuntimeError("CUDA OOM even at grad_accum_steps=1; aborting") from err
+            logger.warning(
+                "CUDA OOM detected; reducing grad_accum_steps from %d to %d and retrying once",
+                self.current_grad_accum_steps,
+                new_accum,
+            )
+            self.current_grad_accum_steps = new_accum
+            self._oom_retry_active = True
+            self.optimizer.zero_grad(set_to_none=True)
+            return StepResult(False, None, 0, 0, 0.0)
+        self._dump_crash("cuda_oom")
+        raise RuntimeError("Repeated CUDA OOM during the same step; aborting") from err
+
+    def _step(self) -> StepResult:
+        self.optimizer.zero_grad(set_to_none=True)
+        use_autocast = self.device.type != "cpu"
+        total_tokens = 0
+        total_examples = 0
+        loss_ce = 0.0
+        loss_kd = 0.0
+        loss_l2 = 0.0
+        loss_total = 0.0
+        step_start = time.perf_counter()
+        current_batches: deque[Dict[str, torch.Tensor]] = deque()
+        try:
+            for _ in range(self.current_grad_accum_steps):
+                if self._retry_batches:
+                    batch = self._retry_batches.popleft()
+                else:
+                    batch = next(self._batch_iterator)
+                current_batches.append(batch)
+                self._last_batch_shapes = {
+                    key: tuple(value.shape)
+                    for key, value in batch.items()
+                    if hasattr(value, "shape")
+                }
+                input_ids = batch["input_ids"].to(self.device)
+                attention_mask = batch.get("attention_mask")
+                if attention_mask is not None:
+                    attention_mask = attention_mask.to(self.device)
+                labels = input_ids[:, 1:].contiguous()
+                student_inputs = input_ids[:, :-1]
+                with torch.autocast(device_type=self.device.type, dtype=self.amp_dtype, enabled=use_autocast):
+                    logits = self.model(student_inputs)
+                    teacher_logits = self._compute_teacher_logits(batch, input_ids)
+                    ce = losses.ce_loss(logits, labels)
+                    kd = logits.new_zeros(())
+                    if teacher_logits is not None:
+                        kd = losses.kd_loss(logits, teacher_logits[:, :-1, :], self.kd_temperature)
+                    l2 = losses.logit_l2(logits, self.logit_reference)
+                    alpha = self.kd_alpha_schedule.value(self.global_step, self.max_steps)
+                    beta = self.ce_beta_schedule.value(self.global_step, self.max_steps)
+                    gamma = self.logit_l2_gamma_schedule.value(self.global_step, self.max_steps)
+                    total_loss = alpha * kd + beta * ce + gamma * l2
+                if not torch.isfinite(total_loss):
+                    return self._handle_non_finite("loss")
+                loss_ce += float(ce.detach().cpu())
+                loss_kd += float(kd.detach().cpu())
+                loss_l2 += float(l2.detach().cpu())
+                loss_total += float(total_loss.detach().cpu())
+                step_loss = total_loss / self.current_grad_accum_steps
+                try:
+                    if self.scaler.is_enabled():
+                        self.scaler.scale(step_loss).backward()
+                    else:
+                        step_loss.backward()
+                except RuntimeError as err:
+                    result = self._handle_oom(err)
+                    if not result.success:
+                        self._retry_batches = current_batches
+                        return result
+                tokens = int(student_inputs.shape[0] * student_inputs.shape[1])
+                if attention_mask is not None:
+                    tokens = int(attention_mask[:, :-1].sum().item())
+                total_tokens += tokens
+                total_examples += int(student_inputs.shape[0])
+        except StopIteration:
+            # Re-raise: our infinite iterator should not exhaust.
+            raise
+        grad_norm = torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
+        if not math.isfinite(float(grad_norm)):
+            return self._handle_non_finite("grad")
+        overflow = False
+        if self.scaler.is_enabled():
+            scale_before = self.scaler.get_scale()
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+            scale_after = self.scaler.get_scale()
+            if scale_after < scale_before:
+                overflow = True
+                logger.warning(
+                    "GradScaler overflow detected (scale %.3e -> %.3e); skipping optimizer step",
+                    scale_before,
+                    scale_after,
+                )
+        if not self.scaler.is_enabled() or not overflow:
+            if not self.scaler.is_enabled():
+                self.optimizer.step()
+            lr = self.scheduler.value(self.global_step)
+            for group in self.optimizer.param_groups:
+                group["lr"] = lr
+            self._consecutive_non_finite = 0
+            self._oom_retry_active = False
+            self._retry_batches.clear()
+            self.optimizer.zero_grad(set_to_none=True)
+            elapsed = max(1e-6, time.perf_counter() - step_start)
+            metrics = {
+                "global_step": self.global_step + 1,
+                "train_loss": loss_total / self.current_grad_accum_steps,
+                "ce_loss": loss_ce / self.current_grad_accum_steps,
+                "kd_loss": loss_kd / self.current_grad_accum_steps,
+                "logit_l2": loss_l2 / self.current_grad_accum_steps,
+                "lr": lr,
+                "tokens_per_sec": total_tokens / elapsed,
+                "examples_per_sec": total_examples / elapsed,
+                "grad_norm": float(grad_norm),
+                "gpu_mem_alloc_MB": self._gpu_mem_mb(),
+            }
+            self._last_metrics = metrics
+            return StepResult(True, metrics, total_tokens, total_examples, float(grad_norm))
+        self.optimizer.zero_grad(set_to_none=True)
+        self._retry_batches = current_batches
+        return StepResult(False, None, total_tokens, total_examples, float(grad_norm))
+
+    def _gpu_mem_mb(self) -> float:
+        if torch.cuda.is_available() and self.device.type == "cuda":
+            return torch.cuda.memory_allocated(self.device) / 1_000_000.0
+        return 0.0
+
+    def _maybe_eval(self) -> float:
+        if self.val_loader is None:
+            return float("inf")
+        metrics = run_validation(self.model, self.val_loader)
+        payload = {"step": self.global_step, **metrics}
+        logger.info("Validation metrics at step %d: %s", self.global_step, json.dumps(metrics))
+        json_log(logger, {"global_step": self.global_step, **metrics})
+        self._write_validation_metrics(payload)
+        val_ppl = float(metrics.get("perplexity", float("inf")))
+        metrics_record = dict(self._last_metrics or {})
+        metrics_record["val_ppl"] = val_ppl
+        metrics_record["global_step"] = self.global_step
+        self._metrics_stream.append(metrics_record)
+        return val_ppl
+
+    def train(self) -> None:
+        dry_batches_seen = 0
+        dry_steps_done = 0
+        with SignalHandler(self):
+            while self.global_step < self.max_steps:
+                result = self._step()
+                if not result.success:
+                    continue
+                self._global_step += 1
+                if result.metrics:
+                    should_log = self.global_step == 1 or (self.global_step % self.metrics_interval == 0)
+                    if should_log:
+                        json_log(logger, result.metrics)
+                        self._metrics_stream.append(result.metrics)
+                dry_steps_done += 1
+                dry_batches_seen += self.current_grad_accum_steps
+                if self.eval_every and self.val_loader is not None and self.global_step % self.eval_every == 0:
+                    val_ppl = self._maybe_eval()
+                    if val_ppl < self._best_ppl:
+                        self._best_ppl = val_ppl
+                        self._save_checkpoint("best.pt", self.global_step, val_ppl, self._last_metrics or {})
+                    if self.early_stop_ppl and val_ppl <= self.early_stop_ppl:
+                        logger.info("Stopping early due to val perplexity %.3f", val_ppl)
+                        break
+                if self.save_every and self.global_step % self.save_every == 0:
+                    self._save_checkpoint("last.pt", self.global_step, self._best_ppl, self._last_metrics or {})
+                if self.dry_run and dry_steps_done >= 1:
+                    while dry_batches_seen < max(2, self.current_grad_accum_steps):
+                        try:
+                            next(self._batch_iterator)
+                            dry_batches_seen += 1
+                        except StopIteration:
+                            break
+                    if self.val_loader is not None:
+                        self._maybe_eval()
+                    self._save_checkpoint("last.pt", self.global_step, self._best_ppl, self._last_metrics or {})
+                    logger.info("Dry run complete; exiting after sanity checks")
+                    break
+        self._metrics_stream.flush()

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/utils.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/stage1/utils.py
@@ -71,6 +71,12 @@ def set_seed(seed: int) -> None:
 
     random.seed(seed)
     torch.manual_seed(seed)
+    try:
+        import numpy as np  # type: ignore
+
+        np.random.seed(seed)
+    except Exception:  # pragma: no cover - optional dependency
+        pass
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
 

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_checkpoint_upload.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_checkpoint_upload.py
@@ -58,8 +58,10 @@ def test_checkpoint_uploads_immediately(tmp_path, monkeypatch):
         save_every=0,
     )
     monkeypatch.setenv("STAGE1_DATA_PROVENANCE_DIR", str(tmp_path))
+    (tmp_path / "frozen_mask.json").write_text("{}", encoding="utf-8")
     with mock.patch("stage1.train.local_to_gcs") as upload_mock:
         trainer._save_checkpoint("last.pt", 0, 1.0, {"loss_total": 0.0})
         destinations = [call.args[1] for call in upload_mock.call_args_list]
         assert f"gs://bucket/path/run123/last.pt" in destinations
         assert f"gs://bucket/path/run123/run_meta.json" in destinations
+        assert f"gs://bucket/path/run123/frozen_mask.json" in destinations

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_dry_run.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_dry_run.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from stage1.train import Trainer
+from stage1.utils import AnnealingSchedule
+
+
+class _MiniModel(torch.nn.Module):
+    def __init__(self, vocab_size: int = 16) -> None:
+        super().__init__()
+        self.embed = torch.nn.Embedding(vocab_size, 8)
+        self.ln = torch.nn.LayerNorm(8)
+        self.lm_head = torch.nn.Linear(8, vocab_size)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        hidden = self.embed(input_ids)
+        hidden = self.ln(hidden)
+        return self.lm_head(hidden)
+
+
+def _collate(batch):
+    input_ids = torch.stack([item[0] for item in batch])
+    return {"input_ids": input_ids}
+
+
+def test_trainer_dry_run(tmp_path):
+    torch.manual_seed(0)
+    dataset = TensorDataset(torch.randint(0, 10, (4, 6)))
+    train_loader = DataLoader(dataset, batch_size=2, collate_fn=_collate)
+    val_loader = DataLoader(dataset, batch_size=2, collate_fn=_collate)
+    model = _MiniModel()
+    trainer = Trainer(
+        model=model,
+        train_loader=train_loader,
+        val_loader=val_loader,
+        device=torch.device("cpu"),
+        output_dir=str(tmp_path),
+        output_gcs_uri=None,
+        run_id="dry",
+        lr=1e-3,
+        betas=(0.9, 0.95),
+        weight_decay=0.0,
+        warmup_steps=0,
+        max_steps=5,
+        kd_temperature=2.0,
+        kd_alpha_schedule=AnnealingSchedule(0.7, 0.4, 0.3),
+        ce_beta_schedule=AnnealingSchedule(0.3, 0.6, 0.3),
+        logit_l2_gamma_schedule=AnnealingSchedule(0.0, 0.0, 1.0),
+        logit_reference=None,
+        precision="fp32",
+        teacher=None,
+        teacher_mode="precompute",
+        teacher_logits_dir=None,
+        eval_every=1,
+        save_every=1,
+        grad_accum_steps=1,
+        metrics_interval=1,
+        dry_run=True,
+    )
+    trainer.train()
+    assert trainer.global_step == 1
+    metrics_path = Path(tmp_path) / "metrics.jsonl"
+    assert metrics_path.exists()
+    last_ckpt = Path(tmp_path) / "last.pt"
+    assert last_ckpt.exists()

--- a/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_precompute_loader.py
+++ b/vertex/package/liquid_llm_vertex_pkg_stage1/tests/test_precompute_loader.py
@@ -1,0 +1,52 @@
+import json
+import sys
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from stage1 import data
+
+
+class _FakeTokenizer:
+    def __init__(self, vocab_size: int = 16, seq_len: int = 8) -> None:
+        self.vocab_size = vocab_size
+        self.seq_len = seq_len
+        self.pad_token = 0
+
+    def __call__(self, text, truncation, max_length, padding, return_tensors):
+        tokens = torch.zeros(max_length, dtype=torch.long)
+        mask = torch.zeros(max_length, dtype=torch.long)
+        length = min(len(text), max_length)
+        if length > 0:
+            tokens[:length] = torch.arange(length) % self.vocab_size
+            mask[:length] = 1
+        return {"input_ids": tokens.unsqueeze(0), "attention_mask": mask.unsqueeze(0)}
+
+
+def test_precompute_loader_includes_teacher_logits(tmp_path):
+    manifest_path = tmp_path / "data.jsonl"
+    sample = {"text": "hello world", "type": "lm", "sample_id": "sample123"}
+    manifest_path.write_text(json.dumps(sample) + "\n", encoding="utf-8")
+
+    entry = data.ManifestEntry(path=str(manifest_path), resolved_path=str(manifest_path), type="lm")
+    tokenizer = _FakeTokenizer()
+    logits_dir = tmp_path / "logits"
+    logits_dir.mkdir()
+    torch.save(torch.randn(tokenizer.seq_len, tokenizer.vocab_size), logits_dir / "sample123.pt")
+
+    dataset = data.ManifestDataset(
+        [entry],
+        tokenizer,
+        seq_len=tokenizer.seq_len,
+        tool_use_ratio=0.0,
+        teacher_mode="precompute",
+        teacher_logits_dir=str(logits_dir),
+    )
+    loader = DataLoader(dataset, batch_size=1, shuffle=False)
+    batch = next(iter(loader))
+    assert "teacher_logits" in batch
+    assert batch["teacher_logits"].shape[-2:] == (tokenizer.seq_len, tokenizer.vocab_size)
+    assert batch["teacher_status"][0] in {"ok", "cached"}


### PR DESCRIPTION
## Summary
- add comprehensive CLI controls, argument snapshotting, startup provenance logging, and data loader tuning for Stage-1 jobs
- harden training loop with NaN/OOM guards, SDPA telemetry, metrics streaming, and resilient checkpoint uploads
- enhance data loader validation, teacher-kd handling, documentation, and unit tests for dry-run, KD, SDPA, and upload flows

## Testing
- `pytest package/liquid_llm_vertex_pkg_stage1/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68f049180e3c83218def02983eb48351