### PR TITLE
Ensure gradients are unscaled before clipping in FP16 training

### DIFF
--- a/vertex/package/stage-1-hybrid/stage1_hybrid/train.py
+++ b/vertex/package/stage-1-hybrid/stage1_hybrid/train.py
@@ -461,6 +461,8 @@ class Trainer:
         except StopIteration:
             # Re-raise: our infinite iterator should not exhaust.
             raise
+        if self.scaler.is_enabled():
+            self.scaler.unscale_(self.optimizer)
         grad_norm = torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
         if not math.isfinite(float(grad_norm)):
             return self._handle_non_finite("grad")


### PR DESCRIPTION
## Summary
- unscale gradients with the AMP GradScaler before applying gradient clipping
- ensure clipping operates on true gradients during fp16 training

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f09bb8e96c8321b151c27b840b3efd