### PR TITLE
Add LLaMA vocabulary surgery notebook

### DIFF
--- a/vertex/Model-Surgery/Model-Surgery/stage1_model_surgery_llama.ipynb
+++ b/vertex/Model-Surgery/Model-Surgery/stage1_model_surgery_llama.ipynb
@@ -1,0 +1,165 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Stage 1 Model Surgery for LLaMA vocab alignment\n\nThis notebook adjusts a student checkpoint to match the tokenizer size for the LLaMA 3.2 3B tokenizer. It ensures the embedding matrices are resized once so future training runs do not need to resize vocabularies at runtime."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "tags": [
+          "parameters"
+        ]
+      },
+      "outputs": [],
+      "source": [
+        "# Parameters\n",
+        "# Update these paths for your environment before running.\n",
+        "STUDENT_IN = \"/path/to/current/student/checkpoint\"\n",
+        "STUDENT_OUT_DIR = \"/path/to/output/checkpoint-128256\"\n",
+        "# Optional: set to a gs:// URI to upload the result. Leave as None to skip.\n",
+        "STUDENT_OUT_GCS = None\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import torch\n",
+        "from transformers import AutoModelForCausalLM, AutoTokenizer\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "TOKENIZER_ID = \"meta-llama/Llama-3.2-3B\"\n",
+        "\n",
+        "# Load the tokenizer and make sure padding is defined.\n",
+        "tok = AutoTokenizer.from_pretrained(TOKENIZER_ID, use_fast=True)\n",
+        "pad_was_added = False\n",
+        "if tok.pad_token_id is None:\n",
+        "    tok.pad_token = tok.eos_token\n",
+        "    pad_was_added = True\n",
+        "\n",
+        "target = len(tok)\n",
+        "print(f\"Tokenizer {TOKENIZER_ID} loaded with {target} tokens.\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "student_path = Path(STUDENT_IN)\n",
+        "if not student_path.exists():\n",
+        "    raise FileNotFoundError(f\"Student checkpoint not found at {student_path}\")\n",
+        "\n",
+        "print(f\"Loading student checkpoint from {student_path}...\")\n",
+        "model = AutoModelForCausalLM.from_pretrained(\n",
+        "    student_path,\n",
+        "    torch_dtype=torch.float16,\n",
+        "    low_cpu_mem_usage=True,\n",
+        ")\n",
+        "\n",
+        "current_vocab = model.get_input_embeddings().weight.size(0)\n",
+        "if current_vocab != target:\n",
+        "    print(f\"Resizing token embeddings from {current_vocab} to {target}.\")\n",
+        "    model.resize_token_embeddings(target)\n",
+        "    if hasattr(model, \"tie_weights\"):\n",
+        "        try:\n",
+        "            model.tie_weights()\n",
+        "        except ValueError as err:\n",
+        "            print(f\"Warning: tie_weights raised ValueError: {err}\")\n",
+        "else:\n",
+        "    print(\"Model embeddings already match tokenizer length; no resize needed.\")\n",
+        "\n",
+        "model.config.vocab_size = target\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "input_embeddings = model.get_input_embeddings().weight.shape\n",
+        "output_embeddings = None\n",
+        "if hasattr(model, \"get_output_embeddings\") and model.get_output_embeddings() is not None:\n",
+        "    output_embeddings = model.get_output_embeddings().weight.shape\n",
+        "\n",
+        "print(\"Tokenizer length:\", len(tok))\n",
+        "print(\"Tokenizer vocab_size attribute:\", getattr(tok, \"vocab_size\", None))\n",
+        "print(\"Input embedding weight shape:\", input_embeddings)\n",
+        "print(\"LM head weight shape:\", output_embeddings)\n",
+        "\n",
+        "assert len(tok) == input_embeddings[0], \"Tokenizer length and model embedding size must match\"\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "output_path = Path(STUDENT_OUT_DIR)\n",
+        "output_path.mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "print(f\"Saving surgically aligned checkpoint to {output_path}\")\n",
+        "model.save_pretrained(output_path)\n",
+        "\n",
+        "if pad_was_added:\n",
+        "    tok.save_pretrained(output_path)\n",
+        "    print(\"Tokenizer saved with updated padding token.\")\n",
+        "else:\n",
+        "    print(\"Tokenizer padding already defined; skipping tokenizer save.\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "if STUDENT_OUT_GCS:\n",
+        "    if not STUDENT_OUT_GCS.startswith(\"gs://\"):\n",
+        "        raise ValueError(\"STUDENT_OUT_GCS must be a gs:// URI\")\n",
+        "    print(f\"Uploading {output_path} to {STUDENT_OUT_GCS}\")\n",
+        "    !gsutil -m cp -r \"${output_path}\" \"${STUDENT_OUT_GCS}\"\n",
+        "else:\n",
+        "    print(\"STUDENT_OUT_GCS not set; skipping upload.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> **Note:** The checkpoint saved at `STUDENT_OUT_DIR` is now the source of truth for vocabulary sizing. Future training runs should load this adjusted checkpoint to avoid runtime resizing.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new Stage 1 notebook that resizes student checkpoints to the LLaMA 3.2 3B tokenizer
- ensure embeddings, pad token handling, saving, and optional GCS upload are covered in the workflow

## Testing
- not run (not required)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d6ed624c483218cc18208f12c1371)